### PR TITLE
WIP: Fixes #170

### DIFF
--- a/autoapi/backends.py
+++ b/autoapi/backends.py
@@ -34,26 +34,4 @@ backend_requirements = {
     "javascript": (),
     "go": (("sphinxcontrib-golangdomain", "sphinxcontrib.golangdomain"),),
     "dotnet": (("sphinxcontrib-dotnetdomain", "sphinxcontrib.dotnetdomain"),),
-}  # type: (Dict[str, Sequence[Tuple[str, str]]])
-
-
-def _get_available_backends():
-    def is_importable(name):
-        try:
-            __import__(name)
-            return True
-        except ModuleNotFoundError:
-            return False
-
-    backends = set()
-    for backend_name, deps in backend_requirements.items():
-        if all(is_importable(import_name) for _, import_name in deps):
-            backends.add(backend_name)
-
-    return backends
-
-
-available_backends = _get_available_backends()
-
-
-del _get_available_backends
+}  # type: Dict[str, Sequence[Tuple[str, str]]]

--- a/autoapi/backends.py
+++ b/autoapi/backends.py
@@ -25,3 +25,35 @@ default_backend_mapping = {
     "go": GoSphinxMapper,
     "javascript": JavaScriptSphinxMapper,
 }
+
+
+#: describes backend requirements in form
+#: {'backend name': (('1st package name in pypi', '1st package import name'), ...)}
+backend_requirements = {
+    "python": (),
+    "javascript": (),
+    "go": (("sphinxcontrib-golangdomain", "sphinxcontrib.golangdomain"),),
+    "dotnet": (("sphinxcontrib-dotnetdomain", "sphinxcontrib.dotnetdomain"),),
+}  # type: (Dict[str, Sequence[Tuple[str, str]]])
+
+
+def _get_available_backends():
+    def is_importable(name):
+        try:
+            __import__(name)
+            return True
+        except ModuleNotFoundError:
+            return False
+
+    backends = set()
+    for backend_name, deps in backend_requirements.items():
+        if all(is_importable(import_name) for _, import_name in deps):
+            backends.add(backend_name)
+
+    return backends
+
+
+available_backends = _get_available_backends()
+
+
+del _get_available_backends

--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -21,6 +21,8 @@ from .backends import (
     default_file_mapping,
     default_ignore_patterns,
     default_backend_mapping,
+    available_backends,
+    backend_requirements,
 )
 from .directives import AutoapiSummary, NestedParse
 from .settings import API_ROOT
@@ -66,6 +68,23 @@ def run_autoapi(app):
         os.path.join(app.confdir, app.config.autoapi_root)
     )
     url_root = os.path.join("/", app.config.autoapi_root)
+
+    # check backend availability
+    # in reality if user will attempt to use `go` api type without
+    #  sphinxcontrib.golangdomain installed, sphinx will prohibit
+    #  all operations because of sphinxcontrib.golangdomain
+    #  extension is required
+    if app.config.autoapi_type not in available_backends:
+        raise ExtensionError(
+            "AutoAPI of type `{type}` requires following "
+            "packages to be installed: {packages}: ".format(
+                type=app.config.autoapi_type,
+                packages=", ".join(
+                    pkg_name
+                    for pkg_name, _ in backend_requirements[app.config.autoapi_type]
+                ),
+            )
+        )
 
     sphinx_mapper = default_backend_mapping[app.config.autoapi_type]
     sphinx_mapper_obj = sphinx_mapper(

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,12 @@ setup(
         'Jinja2',
         'PyYAML',
         'sphinx>=1.6',
-        'sphinxcontrib-golangdomain',
-        'sphinxcontrib-dotnetdomain',
         'unidecode',
     ],
+    extras_require={
+        'go': ['sphinxcontrib-golangdomain'],
+        'dotnet': ['sphinxcontrib-dotnetdomain']
+    },
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ setenv =
 deps = -r{toxinidir}/requirements.txt
     pytest
     mock
+    sphinxcontrib-golangdomain
+    sphinxcontrib-dotnetdomain
     sphinx16: Sphinx<1.7
     sphinx17: Sphinx<1.8
     sphinx18: Sphinx<1.9


### PR DESCRIPTION
As i described in #170, it's really annoying that this library hardly depends on sphinxcontrib-golangdomain and sphinxcontrib-dotnetdomain, so i made a fix attempt and leave it at your discretion

Changes:

* Makes sphinxcontrib-golangdomain and sphinxcontrib-dotnetdomain to be optional packages
* Adds check that appropriate dependencies of a specified api-type installed during the extension initialisation