### PR TITLE
Correction on the "Go" documentation creation with "sphinx-autoapi"

### DIFF
--- a/autoapi/mappers/go.py
+++ b/autoapi/mappers/go.py
@@ -123,10 +123,11 @@ class GoPythonMapper(PythonMapperBase):
         # Second level
         self.imports = obj.get("imports", [])
         self.children = []
-        self.parameters = map(
+        temp_parameters = map(
             lambda n: {"name": n["name"], "type": n["type"].lstrip("*")},
             obj.get("parameters", []),
         )
+        self.parameters = list(temp_parameters)
         self.docstring = obj.get("doc", "")
 
         # Go Specific

--- a/autoapi/templates/go/base_member.rst
+++ b/autoapi/templates/go/base_member.rst
@@ -1,26 +1,32 @@
-.. go:{{ obj.ref_type }}:: {{ obj.name }}
 {% if obj.type == 'func' %}
+    {# Creating the parameters line #}
+    {% set ns = namespace(tmpstring='') %}
     {% set argjoin = joiner(', ') %}
-    ({% for param in obj.parameters %}
-        {{ argjoin() }}{{ param.name }} {{ param.type }}
-    {% endfor %})
+    {% for param in obj.parameters %}
+        {% set ns.tmpstring = ns.tmpstring ~ argjoin() ~ param.name ~ ' ' ~ param.type %}
+    {% endfor %}
+.. {{ obj.ref_type }}:: {{ obj.name }}({{ ns.tmpstring }})
+{% else %}
+.. go:{{ obj.ref_type }}:: {{ obj.name }}
 {% endif %}
 
-    {% macro render() %}{{ obj.docstring }}{% endmacro %}
-    {{ render()|indent(4) }}
+{% macro render() %}{{ obj.docstring }}{% endmacro %}
+{{ render()|indent(4) }}
 
-    {# Don't define parameter description here, that can be done in the block
-    above #}
-    {% for param in obj.parameters %}
-    :type {{ param.name }}: {{ param.type }}
+{# Don't define parameter description here, that can be done in the block
+above #}
+{% for param in obj.parameters %}
+:param {{ param.name }}:
+:type {{ param.name }}: {{ param.type }}
+{% endfor %}
+{% if obj.returns %}
+:rtype: {{ obj.returns.type }}
+{% endif %}
+
+{% if obj.children %}
+    {% for child in obj.children|sort %}
+{% macro render_child() %}{{ child.render() }}{% endmacro %}
+{{ render_child()|indent(4) }}
     {% endfor %}
-    {% if obj.returns %}
-    :rtype: {{ obj.returns.type }}
-    {% endif %}
+{% endif %}
 
-    {% if obj.children %}
-        {% for child in obj.children|sort %}
-    {% macro render_child() %}{{ child.render() }}{% endmacro %}
-    {{ render_child()|indent(4) }}
-        {% endfor %}
-    {% endif %}


### PR DESCRIPTION
These corrections allow to run the example of Go code documentation with the latest version of Sphinx.

Nevertheless, it appears that if we want to use python 3 to launch the documentation generation, the repository "sphinxcontrib-golangdomain" needs to have correction as well. Indeed, some of the code in this directory is python 2 exclusive (iteritems() especially).

This pull request follow the Issue #168 