### PR TITLE
WIP: Implements experimental arbitrary members ignoring capability

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -277,3 +277,4 @@ def setup(app):
     directives.register_directive("autoapi-nested-parse", NestedParse)
     directives.register_directive("autoapisummary", AutoapiSummary)
     app.setup_extension("sphinx.ext.autosummary")
+    app.add_event("autoapi-skip-member")

--- a/autoapi/mappers/base.py
+++ b/autoapi/mappers/base.py
@@ -56,7 +56,8 @@ class PythonMapperBase(object):
     top_level_object = False
     _RENDER_LOG_LEVEL = "VERBOSE"
 
-    def __init__(self, obj, options=None, jinja_env=None, url_root=None):
+    def __init__(self, obj, app=None, options=None, jinja_env=None, url_root=None):
+        self.app = app
         self.obj = obj
         self.options = options
         if jinja_env:

--- a/autoapi/mappers/python/mapper.py
+++ b/autoapi/mappers/python/mapper.py
@@ -286,7 +286,7 @@ class PythonSphinxMapper(SphinxMapperBase):
             obj.submodules.sort()
             obj.subpackages.sort()
 
-    def create_class(self, data, options=None, **kwargs):
+    def create_class(self, data, options=None, parent=None, **kwargs):
         """Create a class from the passed in data
 
         :param data: dictionary data of parser output
@@ -298,6 +298,7 @@ class PythonSphinxMapper(SphinxMapperBase):
         else:
             obj = cls(
                 data,
+                parent=parent,
                 class_content=self.app.config.autoapi_python_class_content,
                 options=self.app.config.autoapi_options,
                 jinja_env=self.jinja_env,
@@ -320,7 +321,7 @@ class PythonSphinxMapper(SphinxMapperBase):
 
             for child_data in data.get("children", []):
                 for child_obj in self.create_class(
-                    child_data, options=options, **kwargs
+                    child_data, parent=obj, options=options, **kwargs
                 ):
                     obj.children.append(child_obj)
             yield obj

--- a/autoapi/mappers/python/mapper.py
+++ b/autoapi/mappers/python/mapper.py
@@ -302,6 +302,7 @@ class PythonSphinxMapper(SphinxMapperBase):
                 options=self.app.config.autoapi_options,
                 jinja_env=self.jinja_env,
                 url_root=self.url_root,
+                app=self.app,
                 **kwargs
             )
 

--- a/autoapi/mappers/python/objects.py
+++ b/autoapi/mappers/python/objects.py
@@ -100,6 +100,22 @@ class PythonPythonMapper(PythonMapperBase):
 
         :type: bool
         """
+        try:
+            skip = (
+                self.app.emit_firstresult(
+                    "autoapi-skip-member",
+                    self._class_content,
+                    self.name,
+                    self,
+                    self.options,
+                )
+                or False
+            )
+            if skip:
+                return False
+        except Exception as exc:
+            raise
+
         if self.is_undoc_member and "undoc-members" not in self.options:
             return False
         if self.is_private_member and "private-members" not in self.options:
@@ -183,10 +199,7 @@ class PythonMethod(PythonFunction):
 
         :type: bool
         """
-        if self.short_name == "__init__":
-            return False
-
-        return super(PythonMethod, self).display
+        return super(PythonMethod, self).display and self.short_name != "__init__"
 
 
 class PythonData(PythonPythonMapper):

--- a/autoapi/mappers/python/parser.py
+++ b/autoapi/mappers/python/parser.py
@@ -142,7 +142,8 @@ class Parser(object):
             type_ = "property"
             properties.append("property")
         else:
-            if node.type in ("staticmethod", "classmethod"):
+            # "__new__" method is implicit classmethod
+            if node.type in ("staticmethod", "classmethod") and node.name != "__new__":
                 properties.append(node.type)
             if node.is_abstract(pass_is_abstract=False):
                 properties.append("abstractmethod")

--- a/tests/python/pyskipexample/conf.py
+++ b/tests/python/pyskipexample/conf.py
@@ -20,8 +20,7 @@ autoapi_type = "python"
 autoapi_dirs = ["example"]
 autoapi_file_pattern = "*.py"
 autoapi_options = ["members", "undoc-members", "special-members"]
-
-SKIP = {"example.foo", "example.Bar", "example.Bar.m", "example.baz"}
+SKIP = {"example.foo", "example.Bar", "example.Bar.m", "example.Baf.m", "example.baz"}
 
 
 def maybe_skip_member(app, what, name, obj, skip, options):

--- a/tests/python/pyskipexample/conf.py
+++ b/tests/python/pyskipexample/conf.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+templates_path = ["_templates"]
+source_suffix = ".rst"
+master_doc = "index"
+project = u"pyexample"
+copyright = u"2015, rtfd"
+author = u"rtfd"
+version = "0.1"
+release = "0.1"
+language = None
+exclude_patterns = ["_build"]
+pygments_style = "sphinx"
+todo_include_todos = False
+html_theme = "alabaster"
+html_static_path = ["_static"]
+htmlhelp_basename = "pyexampledoc"
+extensions = ["sphinx.ext.autodoc", "autoapi.extension"]
+autoapi_type = "python"
+autoapi_dirs = ["example"]
+autoapi_file_pattern = "*.py"
+
+
+SKIP = {"foo", "Bar", "m", "baz"}
+
+
+def maybe_skip_member(app, what, name, obj, options):
+    return name in SKIP
+
+
+def setup(app):
+    app.connect("autoapi-skip-member", maybe_skip_member)

--- a/tests/python/pyskipexample/conf.py
+++ b/tests/python/pyskipexample/conf.py
@@ -19,12 +19,12 @@ extensions = ["sphinx.ext.autodoc", "autoapi.extension"]
 autoapi_type = "python"
 autoapi_dirs = ["example"]
 autoapi_file_pattern = "*.py"
+autoapi_options = ["members", "undoc-members", "special-members"]
+
+SKIP = {"example.foo", "example.Bar", "example.Bar.m", "example.baz"}
 
 
-SKIP = {"foo", "Bar", "m", "baz"}
-
-
-def maybe_skip_member(app, what, name, obj, options):
+def maybe_skip_member(app, what, name, obj, skip, options):
     return name in SKIP
 
 

--- a/tests/python/pyskipexample/example/example.py
+++ b/tests/python/pyskipexample/example/example.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Example module
+
+This is a description
+"""
+
+
+def foo():
+    """foo doc"""
+    pass
+
+
+class Bar:
+    """bar doc"""
+
+    def m(self):
+        """m doc"""
+        pass
+
+
+baz = 100
+"""baz doc"""
+
+
+anchor = "value"
+"""must be in result document because not ignored"""

--- a/tests/python/pyskipexample/example/example.py
+++ b/tests/python/pyskipexample/example/example.py
@@ -14,8 +14,15 @@ class Bar:
     """bar doc"""
 
     def m(self):
-        """m doc"""
+        """bar m doc"""
         pass
+
+
+class Baf:
+    """baf docs"""
+
+    def m(self):
+        """baf m docs"""
 
 
 baz = 100

--- a/tests/python/pyskipexample/index.rst
+++ b/tests/python/pyskipexample/index.rst
@@ -1,0 +1,25 @@
+.. pyexample documentation master file, created by
+   sphinx-quickstart on Fri May 29 13:34:37 2015.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to pyexample's documentation!
+=====================================
+
+.. toctree::
+
+   autoapi/index
+
+Contents:
+
+.. toctree::
+   :maxdepth: 2
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -325,7 +325,9 @@ def test_skiping_members(builder):
 
     assert "foo doc" not in example_file
     assert "Bar doc" not in example_file
-    assert "m doc" not in example_file
+    assert "Bar m doc" not in example_file
+    assert "Baf doc" in example_file
+    assert "Baf m doc" not in example_file
     assert "baz doc" not in example_file
     assert "anchor" in example_file
 
@@ -375,6 +377,14 @@ def test_skip_members_hook(builder):
         ),
         call(
             "autoapi-skip-member",
+            "class",
+            "example.Baf",
+            _CompareInstanceType(PythonClass),
+            False,
+            options,
+        ),
+        call(
+            "autoapi-skip-member",
             "data",
             "example.baz",
             _CompareInstanceType(PythonData),
@@ -393,6 +403,14 @@ def test_skip_members_hook(builder):
             "autoapi-skip-member",
             "method",
             "example.Bar.m",
+            _CompareInstanceType(PythonMethod),
+            False,
+            options,
+        ),
+        call(
+            "autoapi-skip-member",
+            "method",
+            "example.Baf.m",
             _CompareInstanceType(PythonMethod),
             False,
             options,

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -307,6 +307,21 @@ def test_hiding_private_members(builder):
     assert "public_method" in private_file
 
 
+def test_skiping_members(builder):
+    confoverrides = {"autoapi_options": ["members", "undoc-members", "special-members"]}
+    builder("pyskipexample", confoverrides=confoverrides)
+
+    example_path = "_build/text/autoapi/example/index.txt"
+    with io.open(example_path, encoding="utf8") as example_handle:
+        example_file = example_handle.read()
+
+    assert "foo doc" not in example_file
+    assert "Bar doc" not in example_file
+    assert "m doc" not in example_file
+    assert "baz doc" not in example_file
+    assert "anchor" in example_file
+
+
 class TestComplexPackage(object):
     @pytest.fixture(autouse=True, scope="class")
     def built(self, builder):

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -2,11 +2,20 @@ import io
 import os
 import shutil
 import sys
+from mock import patch, Mock, call
 
 import pytest
 import sphinx
 from sphinx.application import Sphinx
 import sphinx.util.logging
+
+from autoapi.mappers.python import (
+    PythonModule,
+    PythonFunction,
+    PythonClass,
+    PythonData,
+    PythonMethod,
+)
 
 
 @pytest.fixture(scope="class")
@@ -308,8 +317,7 @@ def test_hiding_private_members(builder):
 
 
 def test_skiping_members(builder):
-    confoverrides = {"autoapi_options": ["members", "undoc-members", "special-members"]}
-    builder("pyskipexample", confoverrides=confoverrides)
+    builder("pyskipexample")
 
     example_path = "_build/text/autoapi/example/index.txt"
     with io.open(example_path, encoding="utf8") as example_handle:
@@ -320,6 +328,76 @@ def test_skiping_members(builder):
     assert "m doc" not in example_file
     assert "baz doc" not in example_file
     assert "anchor" in example_file
+
+
+class _CompareInstanceType(object):
+    def __init__(self, type_):
+        self.type = type_
+
+    def __eq__(self, other):
+        return self.type is type(other)
+
+    def __repr__(self):
+        return "<expect type {}>".format(self.type.__name__)
+
+
+def test_skip_members_hook(builder):
+    emit_firstresult_patch = Mock(name="emit_firstresult_patch", return_value=False)
+    with patch("sphinx.application.Sphinx.emit_firstresult", emit_firstresult_patch):
+        builder("pyskipexample")
+
+    options = ["members", "undoc-members", "special-members"]
+
+    assert emit_firstresult_patch.mock_calls == [
+        call(
+            "autoapi-skip-member",
+            "module",
+            "example",
+            _CompareInstanceType(PythonModule),
+            False,
+            options,
+        ),
+        call(
+            "autoapi-skip-member",
+            "function",
+            "example.foo",
+            _CompareInstanceType(PythonFunction),
+            False,
+            options,
+        ),
+        call(
+            "autoapi-skip-member",
+            "class",
+            "example.Bar",
+            _CompareInstanceType(PythonClass),
+            False,
+            options,
+        ),
+        call(
+            "autoapi-skip-member",
+            "data",
+            "example.baz",
+            _CompareInstanceType(PythonData),
+            False,
+            options,
+        ),
+        call(
+            "autoapi-skip-member",
+            "data",
+            "example.anchor",
+            _CompareInstanceType(PythonData),
+            False,
+            options,
+        ),
+        call(
+            "autoapi-skip-member",
+            "method",
+            "example.Bar.m",
+            _CompareInstanceType(PythonMethod),
+            False,
+            options,
+        ),
+    ]
 
 
 class TestComplexPackage(object):


### PR DESCRIPTION
As i said in #173, feature to ignore members based on some specific conditions is very desirable. There is prototype of such feature involving *sphinx* events mechanism, work only with Python. I achieved that by emiting `autoapi-skip-member` event which must return something evaluable to `True` for excluding current entity. Event handler signature aims to be as close as possible to the appropriate [autodoc-skip-member](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#event-autodoc-skip-member) handler.

Pease, take a look :)