### PR TITLE
Go mapper improve

### DIFF
--- a/autoapi/mappers/go.py
+++ b/autoapi/mappers/go.py
@@ -128,6 +128,7 @@ class GoPythonMapper(PythonMapperBase):
             obj.get("parameters", []),
         )
         self.parameters = list(temp_parameters)
+        self.results = obj.get("results", [])
         self.docstring = obj.get("doc", "")
 
         # Go Specific

--- a/autoapi/mappers/go.py
+++ b/autoapi/mappers/go.py
@@ -172,6 +172,10 @@ class GoMethod(GoPythonMapper):
     type = "method"
     ref_directive = "meth"
 
+    def __init__(self, obj, **kwargs):
+        super(GoMethod, self).__init__(obj, **kwargs)
+        self.receiver = obj.get("recv")
+
 
 class GoConstant(GoPythonMapper):
     type = "const"

--- a/autoapi/mappers/go.py
+++ b/autoapi/mappers/go.py
@@ -65,7 +65,7 @@ class GoSphinxMapper(SphinxMapperBase):
             _type
                 Set the object class
 
-            consts, types, vars, funcs
+            consts, types, vars, funcs, methods
                 Recurse into :py:meth:`create_class` to create child object
                 instances
 
@@ -96,7 +96,7 @@ class GoSphinxMapper(SphinxMapperBase):
             else:
                 # Recurse for children
                 obj = cls(data, jinja_env=self.jinja_env)
-                for child_type in ["consts", "types", "vars", "funcs"]:
+                for child_type in ["consts", "types", "vars", "funcs", "methods"]:
                     for child_data in data.get(child_type, []):
                         obj.children += list(
                             self.create_class(
@@ -104,7 +104,8 @@ class GoSphinxMapper(SphinxMapperBase):
                                 _type=child_type.replace("consts", "const")
                                 .replace("types", "type")
                                 .replace("vars", "variable")
-                                .replace("funcs", "func"),
+                                .replace("funcs", "func")
+                                .replace("methods", "method"),
                             )
                         )
                 yield obj


### PR DESCRIPTION
- d10207d depends on https://github.com/readthedocs/godocjson/pull/13.
- 7ebb0c6 fixes the probelms that go method are not included in the generated rst, but when render rst to html I get `WARNING: Unknown directive type "go:method"`, any way to fix it?