### PR TITLE
fix 151: support implicit namespace

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -261,6 +261,7 @@ def setup(app):
     app.add_config_value("autoapi_add_toctree_entry", True, "html")
     app.add_config_value("autoapi_template_dir", None, "html")
     app.add_config_value("autoapi_include_summaries", False, "html")
+    app.add_config_value("autoapi_python_use_implicit_namespaces", False, "html")
     app.add_config_value("autoapi_python_class_content", "class", "html")
     app.add_config_value("autoapi_generate_api_docs", True, "html")
     app.add_autodocumenter(documenters.AutoapiFunctionDocumenter)

--- a/autoapi/mappers/python/mapper.py
+++ b/autoapi/mappers/python/mapper.py
@@ -259,11 +259,12 @@ class PythonSphinxMapper(SphinxMapperBase):
                 data["relative_path"] = os.path.relpath(path, dir_root)
                 self.paths[path] = data
 
-    def read_file(self, path, dir_root=None, **kwargs):
+    def read_file(self, path, **kwargs):
         """Read file input into memory, returning deserialized objects
 
         :param path: Path of file to read
         """
+        dir_root = kwargs.get("dir_root")
         try:
             if self._use_implicit_namespace:
                 parsed_data = Parser().parse_file_in_namespace(path, dir_root)
@@ -326,13 +327,8 @@ class PythonSphinxMapper(SphinxMapperBase):
             lines = sphinx.util.docstrings.prepare_docstring(obj.docstring)
             if lines and "autodoc-process-docstring" in self.app.events.events:
                 self.app.emit(
-                    "autodoc-process-docstring",
-                    cls.type,
-                    obj.name,
-                    None,  # object
-                    None,  # options
-                    lines,
-                )
+                    "autodoc-process-docstring", cls.type, obj.name, None, None, lines
+                )  # object  # options
             obj.docstring = "\n".join(lines)
 
             for child_data in data.get("children", []):

--- a/autoapi/mappers/python/parser.py
+++ b/autoapi/mappers/python/parser.py
@@ -32,7 +32,7 @@ class Parser(object):
             module_part = os.path.splitext(filename)[0]
             module_parts = [module_part]
         module_parts = collections.deque(module_parts)
-        while condition(directory):
+        while directory and condition(directory):
             directory, module_part = os.path.split(directory)
             if module_part:
                 module_parts.appendleft(module_part)
@@ -48,7 +48,9 @@ class Parser(object):
         )
 
     def parse_file_in_namespace(self, file_path, dir_root):
-        return self._parse_file(file_path, lambda directory: directory != dir_root)
+        return self._parse_file(
+            file_path, lambda directory: os.path.abspath(directory) != dir_root
+        )
 
     def parse_annassign(self, node):
         return self.parse_assign(node)

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -135,6 +135,13 @@ Customisation Options
 	docstring is empty and the class defines a ``__new__`` with a docstring,
 	the ``__new__`` docstring is used instead of the ``__init__`` docstring.
 
+.. confval:: autoapi_python_use_implicit_namespaces
+
+	Default: ``False``
+
+	Wether to consider all directories as root of namespace.
+	This changes the package detection behaviour to be compatible with PEP420.
+
 Events
 ~~~~~~
 

--- a/tests/python/py3implicitnamespace/conf.py
+++ b/tests/python/py3implicitnamespace/conf.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+templates_path = ["_templates"]
+source_suffix = ".rst"
+master_doc = "index"
+project = u"pyexample"
+copyright = u"2015, rtfd"
+author = u"rtfd"
+version = "0.1"
+release = "0.1"
+language = None
+exclude_patterns = ["_build"]
+pygments_style = "sphinx"
+todo_include_todos = False
+html_theme = "alabaster"
+html_static_path = ["_static"]
+htmlhelp_basename = "py3implicitnamespacedoc"
+extensions = ["sphinx.ext.autodoc", "autoapi.extension"]
+autoapi_type = "python"
+autoapi_dirs = ["namespace"]
+autoapi_file_pattern = "*.py"
+autoapi_python_use_implicit_namespaces = True

--- a/tests/python/py3implicitnamespace/index.rst
+++ b/tests/python/py3implicitnamespace/index.rst
@@ -1,0 +1,26 @@
+.. py3implicitnamespace documentation master file, created by
+   sphinx-quickstart on Fri May 29 13:34:37 2015.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to py3implicitnamespace's documentation!
+================================================
+
+.. toctree::
+
+   autoapi/index
+
+Contents:
+
+.. toctree::
+   :maxdepth: 2
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+

--- a/tests/python/py3implicitnamespace/namespace/example/__init__.py
+++ b/tests/python/py3implicitnamespace/namespace/example/__init__.py
@@ -1,0 +1,7 @@
+from ..sibling import *
+from ..sibling.sub_sibling import *
+
+
+def example_method(foo):
+    """Example method"""
+    pass

--- a/tests/python/py3implicitnamespace/namespace/sibling/__init__.py
+++ b/tests/python/py3implicitnamespace/namespace/sibling/__init__.py
@@ -1,0 +1,8 @@
+def first_method():
+    """First sibling package method."""
+    return 1
+
+
+def second_method():
+    """Second sibling package method."""
+    return 2

--- a/tests/python/py3implicitnamespace/namespace/sibling/sub_sibling.py
+++ b/tests/python/py3implicitnamespace/namespace/sibling/sub_sibling.py
@@ -1,0 +1,8 @@
+def first_sub_method():
+    """First sub-sibling package method."""
+    return 1
+
+
+def second_sub_method():
+    """Second sub-subpackage method."""
+    return 2

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -521,3 +521,26 @@ class TestComplexPackage(object):
             foo_file = foo_handle.read()
 
         assert "unicode_str" in foo_file
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 3), reason="Implicit namespace not supported in python < 3.3"
+)
+class TestImplicitNamespacePackage(object):
+    @pytest.fixture(autouse=True, scope="class")
+    def built(self, builder):
+        builder("py3implicitnamespace")
+
+    def test_sibling_import_from_namespace(self):
+        example_path = "_build/text/autoapi/namespace/example/index.txt"
+        with io.open(example_path, encoding="utf8") as example_handle:
+            example_file = example_handle.read()
+
+        assert "namespace.example.first_method" in example_file
+
+    def test_sub_sibling_import_from_namespace(self):
+        example_path = "_build/text/autoapi/namespace/example/index.txt"
+        with io.open(example_path, encoding="utf8") as example_handle:
+            example_file = example_handle.read()
+
+        assert "namespace.example.second_sub_method" in example_file


### PR DESCRIPTION
As discussed in #151 , this add a new config option `autoapi_python_use_implicit_namespaces` to change the package detection behaviour. 
When used, any folder is considered as a package, even if it does not contain an `__init__.py` file.