### PR TITLE
Fixed table in the tutorial

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -11,14 +11,14 @@ you can following the :doc:`sphinx:usage/quickstart` guide in the Sphinx documen
 The recommended way of installing AutoAPI is through a `virtualenv <https://virtualenv.pypa.io/>`_.
 Once you have a virtualenv set up, you can install AutoAPI with the command::
 
-==========   ==========================================================
-Language     Command
-==========   ==========================================================
-Python       ``pip install sphinx-autoapi``
-Go           ``pip install sphinx-autoapi[go]``
-Javascript   ``pip install sphinx-autoapi``
-.NET         ``pip install sphinx-autoapi[dotnet]``
-==========   ==========================================================
+========== =====================================
+Language   Command
+========== =====================================
+Python     `pip install sphinx-autoapi`
+Go         `pip install sphinx-autoapi[go]`
+Javascript `pip install sphinx-autoapi`
+.NET       `pip install sphinx-autoapi[dotnet]`
+========== =====================================
 
 Depending on which language you are trying to document,
 each language has a different set of steps for finishing the setup of AutoAPI:

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -9,7 +9,7 @@ If you are not sure how to do this,
 you can following the :doc:`sphinx:usage/quickstart` guide in the Sphinx documentation.
 
 The recommended way of installing AutoAPI is through a `virtualenv <https://virtualenv.pypa.io/>`_.
-Once you have a virtualenv set up, you can install AutoAPI with the command::
+Once you have a virtualenv set up, you can install AutoAPI with the commands:
 
 ========== =====================================
 Language   Command
@@ -48,17 +48,17 @@ The directory structure might look like this:
 
     mypackage/
     ├── docs
-    │   ├── _build
-    │   ├── conf.py
-    │   ├── index.rst
-    │   ├── make.bat
-    │   ├── Makefile
-    │   ├── _static
-    │   └── _templates
+    │   ├── _build
+    │   ├── conf.py
+    │   ├── index.rst
+    │   ├── make.bat
+    │   ├── Makefile
+    │   ├── _static
+    │   └── _templates
     ├── mypackage
-    │   ├── _client.py
-    │   ├── __init__.py
-    │   └── _server.py
+    │   ├── _client.py
+    │   ├── __init__.py
+    │   └── _server.py
     └── README.md
 
 ``sphinx-quickstart`` sets up the ``sphinx-build`` to run from
@@ -75,13 +75,13 @@ For example if our source code was inside a ``src/`` directory:
 
     mypackage/
     ├── docs
-    │   ├── _build
-    │   ├── conf.py
-    │   ├── index.rst
-    │   ├── make.bat
-    │   ├── Makefile
-    │   ├── _static
-    │   └── _templates
+    │   ├── _build
+    │   ├── conf.py
+    │   ├── index.rst
+    │   ├── make.bat
+    │   ├── Makefile
+    │   ├── _static
+    │   └── _templates
     ├── README.md
     └── src
         └── mypackage


### PR DESCRIPTION
I realized that there was a `::` before the table, which screwed it up.