### PR TITLE
Show black diff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: xenial
 language: python
 install:
@@ -9,7 +10,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
-matrix:
+jobs:
   include:
     - python: 3.8
       env: TOXENV=docs

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -239,7 +239,10 @@ class TestPositionalOnlyArgumentsModule(object):
             "f_annotation(a: int, b: int, /, c: Optional[int], d: Optional[int], *, e: float, f: float)"
             in example_file
         )
-        assert "f_arg_comment(a: int, b: int, /, c: Optional[int], d: Optional[int], *, e: float, f: float)" in example_file
+        assert (
+            "f_arg_comment(a: int, b: int, /, c: Optional[int], d: Optional[int], *, e: float, f: float)"
+            in example_file
+        )
         assert "f_no_cd(a: int, b: int, /, *, e: float, f: float)" in example_file
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ skip_install = true
 deps =
     black
 commands =
-    black --check autoapi tests
+    black --check --diff autoapi tests
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
This shows the required changes to satisfy black. Therefore it is easier to fix stuff in browser only, without cloning the repo or installing black.