### PR TITLE
Added default golang ingore pattern to remove unit tests by default

### DIFF
--- a/autoapi/backends.py
+++ b/autoapi/backends.py
@@ -16,7 +16,7 @@ DEFAULT_FILE_PATTERNS = {
 DEFAULT_IGNORE_PATTERNS = {
     "dotnet": ["*toc.yml", "*index.yml"],
     "python": ["*migrations*"],
-    "go": ["*_test.go"],
+    "go": ["_test.go"],
 }
 
 

--- a/autoapi/backends.py
+++ b/autoapi/backends.py
@@ -16,6 +16,7 @@ DEFAULT_FILE_PATTERNS = {
 DEFAULT_IGNORE_PATTERNS = {
     "dotnet": ["*toc.yml", "*index.yml"],
     "python": ["*migrations*"],
+    "go": ["*_test.go"],
 }
 
 


### PR DESCRIPTION
With this, golang test files are ignored.
since godocjson is shall be called like this to ignore tests we do not need no wildcard symbol (*)
```
godocjson  -e _test.go fobarpath
```