### PR TITLE
Set self.parent in import_object

### DIFF
--- a/autoapi/documenters.py
+++ b/autoapi/documenters.py
@@ -46,13 +46,16 @@ class AutoapiDocumenter(autodoc.Documenter):
         for num_splits in range(max_splits, -1, -1):
             path_stack = list(reversed(self.fullname.rsplit(".", num_splits)))
             objects = self.env.autoapi_mapper.objects
-            parent = objects.get(path_stack.pop())
-            while parent and path_stack:
-                parent = self.get_attr(parent, path_stack.pop(), None)
+            parent = None
+            current = objects.get(path_stack.pop())
+            while current and path_stack:
+                parent = current
+                current = self.get_attr(current, path_stack.pop(), None)
 
-            if parent:
-                self.object = parent
-                self.object_name = parent.name
+            if current:
+                self.object = current
+                self.object_name = current.name
+                self._method_parent = parent
                 return True
 
         return False
@@ -200,6 +203,7 @@ class AutoapiMethodDocumenter(
         result = super(AutoapiMethodDocumenter, self).import_object()
 
         if result:
+            self.parent = self._method_parent
             if self.object.method_type != "method":
                 if sphinx.version_info < (2, 1):
                     self.directivetype = self.object.method_type

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -52,7 +52,6 @@ class TestSimpleModule(object):
     def test_integration(self):
         self.check_integration("_build/text/autoapi/example/index.txt")
 
-    @pytest.mark.xfail(sphinx.version_info >= (3, 1), reason="Issue #227")
     def test_manual_directives(self):
         example_path = "_build/text/manualapi.txt"
         # The manual directives should contain the same information


### PR DESCRIPTION
Fixes https://github.com/readthedocs/sphinx-autoapi/issues/227

At least as far as I can tell. The error appears to originate in https://github.com/sphinx-doc/sphinx/blob/9a2f2e15a6c2149a84d91f34f18695086dc47f90/sphinx/ext/autodoc/__init__.py#L1771 