### PR TITLE
Fix #234: Inject TOCs just after doctrees are read

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -186,6 +186,9 @@ def doctree_read(app, doctree):
     """
     Inject AutoAPI into the TOC Tree dynamically.
     """
+
+    add_domain_to_toctree(app, doctree, app.env.docname)
+
     if app.env.docname == "index":
         all_docs = set()
         insert = True
@@ -279,7 +282,6 @@ def viewcode_follow_imported(app, modname, attribute):
 def setup(app):
     app.connect("builder-inited", run_autoapi)
     app.connect("doctree-read", doctree_read)
-    app.connect("doctree-resolved", add_domain_to_toctree)
     app.connect("build-finished", build_finished)
     app.connect("env-updated", clear_env)
     if sphinx.version_info >= (1, 8):


### PR DESCRIPTION
This PR moves the TOC-injection process from the writing phase to the resolving phase.

I think this will solve the issue discussed in #234.

(However, I'm afraid it causes any side-effects I haven't noticed. Are there any reasons to do this at `doctree-resolved`?)

Here is an example build result. Things after "index" are shown:

<img width="495" alt="sc" src="https://user-images.githubusercontent.com/5351911/89101800-7c7f4d80-d43e-11ea-8e25-346a1c199b8a.png">

Close #234