### PR TITLE
Make NestedParse not to wrap their content with a paragraph

### DIFF
--- a/autoapi/directives.py
+++ b/autoapi/directives.py
@@ -48,7 +48,7 @@ class NestedParse(Directive):  # pylint: disable=too-few-public-methods
     option_spec = {}
 
     def run(self):
-        node = nodes.paragraph()
+        node = nodes.container()
         node.document = self.state.document
         nested_parse_with_titles(self.state, self.content, node)
         try:
@@ -57,4 +57,4 @@ class NestedParse(Directive):  # pylint: disable=too-few-public-methods
                 del node[0][0]
         except IndexError:
             pass
-        return [node]
+        return node.children


### PR DESCRIPTION
I found the `autoapi-nested-parse` directive unnecessarily (or sometimes illegally) wraps its content with a paragraph.

This PR fixes this issue. For example:

![Untitled-2](https://user-images.githubusercontent.com/5351911/89124223-48745d00-d510-11ea-94a5-672283c99f96.png)
