### PR TITLE
Add support for overloaded functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,15 @@
 repos:
-￼-   repo: https://github.com/ambv/black
-￼    rev: 18.9b0
-￼    hooks:
-￼    - id: black
-      language_version: python3.6
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
+      - id: black
+        language_version: python3
+-   repo: https://github.com/PyCQA/pylint
+    rev: 'pylint-2.5.3'
+    hooks:
+      - id: pylint
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer

--- a/autoapi/directives.py
+++ b/autoapi/directives.py
@@ -20,7 +20,7 @@ class AutoapiSummary(Autosummary):  # pylint: disable=too-few-public-methods
         for name in names:
             obj = mapper.all_objects[name]
             if isinstance(obj, PythonFunction):
-                if len(obj.signatures) > 1:
+                if obj.overloads:
                     sig = "(\u2026)"
                 else:
                     sig = "({})".format(obj.args)

--- a/autoapi/directives.py
+++ b/autoapi/directives.py
@@ -20,9 +20,12 @@ class AutoapiSummary(Autosummary):  # pylint: disable=too-few-public-methods
         for name in names:
             obj = mapper.all_objects[name]
             if isinstance(obj, PythonFunction):
-                sig = "({})".format(obj.args)
-                if obj.return_annotation is not None:
-                    sig += " -> {}".format(obj.return_annotation)
+                if len(obj.signatures) > 1:
+                    sig = "(\u2026)"
+                else:
+                    sig = "({})".format(obj.args)
+                    if obj.return_annotation is not None:
+                        sig += " \u2192 {}".format(obj.return_annotation)
             else:
                 sig = ""
 

--- a/autoapi/mappers/python/astroid_utils.py
+++ b/autoapi/mappers/python/astroid_utils.py
@@ -275,6 +275,42 @@ def is_decorated_with_property_setter(node):
     return False
 
 
+def is_decorated_with_overload(node):
+    """Check if the function is decorated as an overload definition.
+
+    :param node: The node to check.
+    :type node: astroid.nodes.FunctionDef
+
+    :returns: True if the function is an overload definition, False otherwise.
+    :rtype: bool
+    """
+    if not node.decorators:
+        return False
+
+    for decorator in node.decorators.nodes:
+        if not isinstance(decorator, (astroid.Name, astroid.Attribute)):
+            continue
+
+        try:
+            if _is_overload_decorator(decorator):
+                return True
+        except astroid.InferenceError:
+            pass
+
+    return False
+
+
+def _is_overload_decorator(decorator):
+    for inferred in decorator.infer():
+        if not isinstance(inferred, astroid.nodes.FunctionDef):
+            continue
+
+        if inferred.name == "overload" and inferred.root().name == "typing":
+            return True
+
+    return False
+
+
 def is_constructor(node):
     """Check if the function is a constructor.
 

--- a/autoapi/mappers/python/objects.py
+++ b/autoapi/mappers/python/objects.py
@@ -183,11 +183,8 @@ class PythonFunction(PythonPythonMapper):
 
         :type: list(str)
         """
-        self.signatures = obj["signatures"]
-        """The list of all signatures ``[(args, return_annotation), ...]`` of this function.
-
-        When this function is not overloaded,
-        it must be the same as ``[(self.args, self.return_annotation)]``.
+        self.overloads = obj["overloads"]
+        """The list of overloaded signatures ``[(args, return_annotation), ...]`` of this function.
 
         :type: list(tuple(str, str))
         """

--- a/autoapi/mappers/python/objects.py
+++ b/autoapi/mappers/python/objects.py
@@ -183,6 +183,14 @@ class PythonFunction(PythonPythonMapper):
 
         :type: list(str)
         """
+        self.signatures = obj["signatures"]
+        """The list of all signatures ``[(args, return_annotation), ...]`` of this function.
+
+        When this function is not overloaded,
+        it must be the same as ``[(self.args, self.return_annotation)]``.
+
+        :type: list(tuple(str, str))
+        """
 
 
 class PythonMethod(PythonFunction):

--- a/autoapi/mappers/python/parser.py
+++ b/autoapi/mappers/python/parser.py
@@ -98,7 +98,7 @@ class Parser(object):
 
         return [data]
 
-    def parse_classdef(self, node, data=None):
+    def parse_classdef(self, node, data=None):  # pylint: disable=too-many-branches
         type_ = "class"
         if astroid_utils.is_exception(node):
             type_ = "exception"
@@ -129,6 +129,7 @@ class Parser(object):
         self._name_stack.append(node.name)
         overridden = set()
         overloads = {}
+        # pylint: disable=too-many-nested-blocks
         for base in itertools.chain(iter((node,)), node.ancestors()):
             seen = set()
             if base.qname() in ("__builtins__.object", "builtins.object"):

--- a/autoapi/mappers/python/parser.py
+++ b/autoapi/mappers/python/parser.py
@@ -200,6 +200,7 @@ class Parser(object):
             "return_annotation": return_annotation,
             "properties": properties,
             "is_overload": astroid_utils.is_decorated_with_overload(node),
+            "overloads": [],
         }
 
         if type_ in ("method", "property"):
@@ -291,21 +292,14 @@ def _parse_child(node, child_data, overloads, base=None, name=None):
                 name = single_data["name"]
             if name in overloads:
                 grouped = overloads[name]
-                if single_data["doc"]:
-                    grouped["doc"] += "\n\n" + single_data["doc"]
+                grouped["doc"] = single_data["doc"]
                 if single_data["is_overload"]:
-                    grouped["signatures"].append(
+                    grouped["overloads"].append(
                         (single_data["args"], single_data["return_annotation"])
                     )
-                else:
-                    grouped["args"] = single_data["args"]
-                    grouped["return_annotation"] = single_data["return_annotation"]
                 continue
             if single_data["is_overload"] and name not in overloads:
                 overloads[name] = single_data
-            single_data["signatures"] = [
-                (single_data["args"], single_data["return_annotation"])
-            ]
 
         if base:
             single_data["inherited"] = base is not node

--- a/autoapi/templates/python/function.rst
+++ b/autoapi/templates/python/function.rst
@@ -1,6 +1,13 @@
 {% if obj.display %}
-.. function:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
+{% for (args, return_annotation) in obj.signatures %}
+{% if loop.index0 == 0 %}
+.. function:: {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
 
+{% else %}
+              {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+
+{% endif %}
+{% endfor %}
    {% if sphinx_version >= (2, 1) %}
    {% for property in obj.properties %}
    :{{ property }}:

--- a/autoapi/templates/python/function.rst
+++ b/autoapi/templates/python/function.rst
@@ -1,12 +1,9 @@
 {% if obj.display %}
-{% for (args, return_annotation) in obj.signatures %}
-{% if loop.index0 == 0 %}
-.. function:: {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+.. function:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
 
-{% else %}
+{% for (args, return_annotation) in obj.overloads %}
               {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
 
-{% endif %}
 {% endfor %}
    {% if sphinx_version >= (2, 1) %}
    {% for property in obj.properties %}

--- a/autoapi/templates/python/method.rst
+++ b/autoapi/templates/python/method.rst
@@ -1,13 +1,10 @@
 {%- if obj.display %}
 {% if sphinx_version >= (2, 1) %}
-{% for (args, return_annotation) in obj.signatures %}
-{% if loop.index0 == 0 %}
-.. method:: {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+.. method:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
 
-{% else %}
+{% for (args, return_annotation) in obj.overloads %}
             {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
 
-{% endif %}
 {% endfor %}
    {% if obj.properties %}
    {% for property in obj.properties %}
@@ -18,15 +15,11 @@
 
    {% endif %}
 {% else %}
-{% for (args, return_annotation) in obj.signatures %}
-{% if loop.index0 == 0 %}
-.. {{ obj.method_type }}:: {{ obj.short_name }}({{ args }})
-
-{% else %}
-                        :: {{ obj.short_name }}({{ args }})
-
-{% endif %}
+.. {{ obj.method_type }}:: {{ obj.short_name }}({{ obj.args }})
+{% for (args, return_annotation) in obj.overloads %}
+   {{ " " * (obj.method_type | length) }}   {{ obj.short_name }}({{ args }})
 {% endfor %}
+
 {% endif %}
    {% if obj.docstring %}
    {{ obj.docstring|prepare_docstring|indent(3) }}

--- a/autoapi/templates/python/method.rst
+++ b/autoapi/templates/python/method.rst
@@ -1,19 +1,33 @@
 {%- if obj.display %}
 {% if sphinx_version >= (2, 1) %}
-.. method:: {{ obj.short_name }}({{ obj.args }}){% if obj.return_annotation is not none %} -> {{ obj.return_annotation }}{% endif %}
-   {% if obj.properties %}
+{% for (args, return_annotation) in obj.signatures %}
+{% if loop.index0 == 0 %}
+.. method:: {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
 
+{% else %}
+            {{ obj.short_name }}({{ args }}){% if return_annotation is not none %} -> {{ return_annotation }}{% endif %}
+
+{% endif %}
+{% endfor %}
+   {% if obj.properties %}
    {% for property in obj.properties %}
    :{{ property }}:
    {% endfor %}
+
    {% else %}
 
    {% endif %}
 {% else %}
-.. {{ obj.method_type }}:: {{ obj.short_name }}({{ obj.args }})
+{% for (args, return_annotation) in obj.signatures %}
+{% if loop.index0 == 0 %}
+.. {{ obj.method_type }}:: {{ obj.short_name }}({{ args }})
+
+{% else %}
+                        :: {{ obj.short_name }}({{ args }})
 
 {% endif %}
-
+{% endfor %}
+{% endif %}
    {% if obj.docstring %}
    {{ obj.docstring|prepare_docstring|indent(3) }}
    {% endif %}

--- a/tests/python/py3example/example/example.py
+++ b/tests/python/py3example/example/example.py
@@ -4,7 +4,8 @@
 This is a description
 """
 import asyncio
-from typing import ClassVar, Dict, Iterable, List, Union
+import typing
+from typing import ClassVar, Dict, Iterable, List, Union, overload
 
 max_rating: int = 10
 
@@ -35,7 +36,33 @@ def f2(not_yet_a: "A") -> int:
     ...
 
 
+@overload
+def overloaded_func(a: float) -> float:
+    ...
+
+
+@typing.overload
+def overloaded_func(a: str) -> str:
+    ...
+
+
+def overloaded_func(a: Union[float, str]) -> Union[float, str]:
+    """Overloaded function"""
+    return a * 2
+
+
+@overload
+def undoc_overloaded_func(a: str) -> str:
+    ...
+
+
+def undoc_overloaded_func(a: str) -> str:
+    return a * 2
+
+
 class A:
+    """class A"""
+
     is_an_a: ClassVar[bool] = True
     not_assigned_to: ClassVar[str]
 
@@ -56,6 +83,40 @@ class A:
     def my_method(self) -> str:
         """My method."""
         return "method"
+
+    @overload
+    def overloaded_method(self, a: float) -> float:
+        ...
+
+    @typing.overload
+    def overloaded_method(self, a: str) -> str:
+        ...
+
+    def overloaded_method(self, a: Union[float, str]) -> Union[float, str]:
+        """Overloaded method"""
+        return a * 2
+
+    @overload
+    def undoc_overloaded_method(self, a: float) -> float:
+        ...
+
+    def undoc_overloaded_method(self, a: float) -> float:
+        return a * 2
+
+    @typing.overload
+    @classmethod
+    def overloaded_class_method(cls, a: float) -> float:
+        ...
+
+    @overload
+    @classmethod
+    def overloaded_class_method(cls, a: str) -> str:
+        ...
+
+    @classmethod
+    def overloaded_class_method(cls, a: Union[float, str]) -> Union[float, str]:
+        """Overloaded class method"""
+        return a * 2
 
 
 async def async_function(self, wait: bool) -> int:

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -177,6 +177,29 @@ class TestPy3Module(object):
         if sphinx.version_info >= (2, 1):
             assert "my_method(self) -> str" in example_file
 
+    def test_overload(self):
+        example_path = "_build/text/autoapi/example/index.txt"
+        with io.open(example_path, encoding="utf8") as example_handle:
+            example_file = example_handle.read()
+
+        assert "overloaded_func(a: float" in example_file
+        assert "overloaded_func(a: str" in example_file
+        assert "overloaded_func(a: Union" not in example_file
+        assert "Overloaded function" in example_file
+
+        assert "overloaded_method(self, a: float" in example_file
+        assert "overloaded_method(self, a: str" in example_file
+        assert "overloaded_method(self, a: Union" not in example_file
+        assert "Overloaded method" in example_file
+
+        assert "overloaded_class_method(cls, a: float" in example_file
+        assert "overloaded_class_method(cls, a: str" in example_file
+        assert "overloaded_class_method(cls, a: Union" not in example_file
+        assert "Overloaded method" in example_file
+
+        assert "undoc_overloaded_func" in example_file
+        assert "undoc_overloaded_method" in example_file
+
     def test_async(self):
         example_path = "_build/text/autoapi/example/index.txt"
         with io.open(example_path, encoding="utf8") as example_handle:
@@ -188,6 +211,23 @@ class TestPy3Module(object):
         else:
             assert "async_method" in example_file
             assert "async_function" in example_file
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 6), reason="Annotations are invalid in Python <3.5"
+)
+def test_py3_hiding_undoc_overloaded_members(builder):
+    confoverrides = {"autoapi_options": ["members", "special-members"]}
+    builder("py3example", confoverrides=confoverrides)
+
+    example_path = "_build/text/autoapi/example/index.txt"
+    with io.open(example_path, encoding="utf8") as example_handle:
+        example_file = example_handle.read()
+
+    assert "overloaded_func" in example_file
+    assert "overloaded_method" in example_file
+    assert "undoc_overloaded_func" not in example_file
+    assert "undoc_overloaded_method" not in example_file
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR adds basic support for the `typing.overload` decorator.

It works by storing all the overloaded signatures into the first definition.

Input:

```python
class Double:
    """This is a class"""
    @overload
    def double(self, a: int) -> int: ...
    @overload
    def double(self, a: str) -> str: ...
    def double(self, a: Union[int, str]) -> Union[str, int]:
        """This is an overloaded method"""
        return a * 2

@overload
def double(a: int) -> int: ...
@overload
def double(a: str) -> str: ...
def double(a: Union[int, str]) -> Union[int, str]:
    """This is an overloaded function"""
    return a * 2
```

Output:

<img width="301" alt="html output" src="https://user-images.githubusercontent.com/5351911/89515309-e4081500-d811-11ea-9839-e6d3c5a3f51f.png">

Please check the `tests/python/py3example` for details.

(This PR also fixes the issue that the autoapi silently drops duplicated methods in the same class.)

Close #217 