### PR TITLE
Fix inheritance diagram from module

### DIFF
--- a/autoapi/inheritance_diagrams.py
+++ b/autoapi/inheritance_diagrams.py
@@ -52,7 +52,7 @@ def _import_class(name, currmodule):
 
     if isinstance(target, astroid.Module):
         classes = []
-        for child in target.children:
+        for child in target.get_children():
             if isinstance(child, astroid.ClassDef):
                 classes.append(child)
         return classes


### PR DESCRIPTION
`astroid.Module` has a `get_children()` function, but no `children` field. (I think the `body` field should also work here)

http://pylint.pycqa.org/projects/astroid/en/latest/api/astroid.nodes.html#astroid.nodes.Module.get_children