### PR TITLE
Update Go docs to no longer use abandoned domain

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -112,7 +112,9 @@ Support for Go requires you to have the go environment installed
 
 and the Go domain extension for Sphinx::
 
-    pip install sphinxcontrib-golangdomain
+    git clone https://github.com/chrisdoherty4/sphinxcontrib-golangdomain
+    cd sphinxcontrib-golangdomain
+    pip install .
 
 To enable the AutoAPI extension,
 we need to add it to the list of extensions in Sphinx's ``conf.py`` file


### PR DESCRIPTION
Update Go docs to no longer use abandoned golangdomain project. The one hosted on pip and referenced in the documentation has been abandoned for years. It has been forked and updated by @chrisdoherty4.