### PR TITLE
Minor internal test warnings fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog
 
 Versions follow `Semantic Versioning <https://semver.org/>`_ (``<major>.<minor>.<patch>``).
 
+UNRELEASED (2021-MM-DD)
+-----------------------
+
+Trivial/Internal Changes
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Fixed `DeprecationWarning` for invalid escape sequence `\s` in tests.
+* Fixed `FutureWarning` for `Node.traverse()` becoming an iterator instead of list.
+
+
 V1.7.0 (2021-01-31)
 -------------------
 

--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -198,7 +198,7 @@ def doctree_read(app, doctree):
     if app.env.docname == "index":
         all_docs = set()
         insert = True
-        nodes = doctree.traverse(toctree)
+        nodes = list(doctree.traverse(toctree))
         toc_entry = "%s/index" % app.config.autoapi_root
         add_entry = (
             nodes

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -144,12 +144,12 @@ class DotNetPythonMapperTests(unittest.TestCase):
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'With surrounding characters s<see cref="FOO" />s'
         )
-        self.assertEqual(ret, "With surrounding characters s :any:`FOO`\s")
+        self.assertEqual(ret, r"With surrounding characters s :any:`FOO`\s")
 
         ret = dotnet.DotNetPythonMapper.transform_doc_comments(
             'With surrounding characters s<paramref name="FOO" />s'
         )
-        self.assertEqual(ret, "With surrounding characters s ``FOO``\s")
+        self.assertEqual(ret, r"With surrounding characters s ``FOO``\s")
 
     def test_xml_transform_escape(self):
         """XML transform escaping"""


### PR DESCRIPTION
Just minor trivial things from when I was running tests prior to working on new changes/features

### Fixed

- `DeprecationWarning` for invalid escape sequence `\s` in tests.
- `FutureWarning` for `Node.traverse()` becoming an iterator instead of list.

There is still a `DeprecationWarning` for `import imp` but that is probably beyond the scope of these trivial fixes

<details><summary>py37-sphinx30 test output @ v1.7.0</summary>

```
.tox/py37/lib/python3.7/site-packages/astroid/interpreter/_import/spec.py:15
  /home/joseph/repos/sphinx-autoapi/.tox/py37/lib/python3.7/site-packages/astroid/interpreter/_import/spec.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

tests/test_domains.py:147
  /home/joseph/repos/sphinx-autoapi/tests/test_domains.py:147: DeprecationWarning: invalid escape sequence \s
    self.assertEqual(ret, "With surrounding characters s :any:`FOO`\s")

tests/test_domains.py:152
  /home/joseph/repos/sphinx-autoapi/tests/test_domains.py:152: DeprecationWarning: invalid escape sequence \s
    self.assertEqual(ret, "With surrounding characters s ``FOO``\s")

tests/test_integration.py::TOCTreeTests::test_toctree_domain_insertion
tests/test_integration.py::TOCTreeTests::test_toctree_overrides
  /home/joseph/repos/sphinx-autoapi/.tox/py37-sphinx30/lib/python3.7/site-packages/autoapi/extension.py:220: FutureWarning: 
     The iterable returned by Node.traverse()
     will become an iterator instead of a list in Docutils > 0.16.
    nodes[-1]["entries"].append((None, u"%s/index" % app.config.autoapi_root))
```

</details>