### PR TITLE
Fix multiline string data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog
 
 Versions follow `Semantic Versioning <https://semver.org/>`_ (``<major>.<minor>.<patch>``).
 
+UNRELEASED (2021-MM-DD)
+-----------------------
+
+Features
+^^^^^^^^
+
+* `#267 <https://github.com/readthedocs/sphinx-autoapi/issues/267>` 
+  Expandable value for multi-line string attibutes.
+
+
 V1.7.0 (2021-01-31)
 -------------------
 

--- a/autoapi/templates/python/data.rst
+++ b/autoapi/templates/python/data.rst
@@ -1,6 +1,31 @@
 {% if obj.display %}
 .. {{ obj.type }}:: {{ obj.name }}
-   {%+ if obj.value is not none or obj.annotation is not none %}:annotation:{% if obj.annotation %} :{{ obj.annotation }}{% endif %}{% if obj.value is not none %} = {{ obj.value }}{% endif %}{% endif %}
+   {%+ if obj.value is not none or obj.annotation is not none -%}
+   :annotation:
+        {%- if obj.annotation %} :{{ obj.annotation }}
+        {%- endif %}
+        {%- if obj.value is not none %} = {%
+            if obj.value is string and obj.value.splitlines()|count > 1 -%}
+                Multiline-String
+
+    .. raw:: html
+
+        <details><summary>Show Value</summary>
+
+    .. code-block:: text
+        :linenos:
+
+        {{ obj.value|indent(width=8) }}
+
+    .. raw:: html
+
+        </details>
+
+            {%- else -%}
+                {{ obj.value|string|truncate(100) }}
+            {%- endif %}
+        {%- endif %}
+    {% endif %}
 
 
    {{ obj.docstring|prepare_docstring|indent(3) }}

--- a/tests/python/py3example/example/example.py
+++ b/tests/python/py3example/example/example.py
@@ -10,6 +10,17 @@ from typing import ClassVar, Dict, Iterable, List, Union, overload
 from example2 import B
 
 
+software = "sphinx"
+
+code_snippet = """
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+# from future.builtins.disabled import *
+# from builtins import *
+
+print("chunky o'block")
+"""
+
 max_rating: int = 10
 
 is_valid: bool

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -4,7 +4,6 @@ import re
 import shutil
 import sys
 from mock import patch, Mock, call
-import textwrap
 
 import pytest
 import sphinx


### PR DESCRIPTION
Encountered an issue where multi-line string attributes (e.g. code snippets) will run into the next line, causing restructuredText errors and badly rendered HTML.

![sphinx-autoapi-data-multiline](https://user-images.githubusercontent.com/9294702/107966236-777d8800-6fa3-11eb-8565-1b0ddaabfcde.gif)

> **Left**: Rendered HTML from... **Right**: Generated `.rst` 

## Proposal

Use the `<details>...</details>` HTML markup to render multi-line strings in a toggle-able, plain-text code block.

---

### Added

- Expandable toggle for multi-line values (data annotations)