### PR TITLE
Added autoapi-skip-member example

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog
 
 Versions follow `Semantic Versioning <https://semver.org/>`_ (``<major>.<minor>.<patch>``).
 
+
+UNRELEASED (2021-MM-DD)
+-----------------------
+
+Trivial/Internal Changes
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* New example implementation of `autoapi-skip-member` Sphinx event.
+
+
 V1.7.0 (2021-01-31)
 -------------------
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -237,7 +237,7 @@ The following events allow you to control the behaviour of AutoAPI.
    behaviour of AutoAPI or another attached handler.
 
    .. code-block:: python
-      :caption: inside conf.py
+      :caption: Example conf.py
 
       def skip_util_classes(app, what, name, obj, skip, options):
           if what == "class" and "util" in name:

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -236,6 +236,17 @@ The following events allow you to control the behaviour of AutoAPI.
    Handlers should return ``None`` to fall back to the default skipping
    behaviour of AutoAPI or another attached handler.
 
+   .. code-block:: python
+      :caption: inside conf.py
+
+      def skip_util_classes(app, what, name, obj, skip, options):
+          if what == "class" and "util" in name:
+             skip = True
+          return skip
+
+      def setup(sphinx):
+         sphinx.connect("autoapi-skip-member", skip_util_classes)
+
    :param app: The Sphinx application object.
    :param what: The type of the object which the docstring belongs to.
       This can be one of:


### PR DESCRIPTION
Just a quick example to illustrate how to register events in Sphinx, which very subtly [mentioned in their official documentations](https://www.sphinx-doc.org/en/master/extdev/appapi.html?highlight=conf#sphinx-core-events) and may catch out new users.

![image](https://user-images.githubusercontent.com/9294702/107980358-04324100-6fb8-11eb-917d-e03c017c893a.png)
