### PR TITLE
Logging types and subtypes

### DIFF
--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -104,9 +104,11 @@ class DotNetSphinxMapper(SphinxMapperBase):
                 )
                 _, error_output = proc.communicate()
                 if error_output:
-                    LOGGER.warning(error_output)
+                    LOGGER.warning(error_output, type="autoapi")
             except (OSError, subprocess.CalledProcessError):
-                LOGGER.warning("Error generating metadata", exc_info=True)
+                LOGGER.warning(
+                    "Error generating metadata", exc_info=True, type="autoapi"
+                )
                 if raise_error:
                     raise ExtensionError(
                         "Failure in docfx while generating AutoAPI output."
@@ -131,9 +133,9 @@ class DotNetSphinxMapper(SphinxMapperBase):
                 parsed_data = yaml.safe_load(handle)
                 return parsed_data
         except IOError:
-            LOGGER.warning("Error reading file: {0}".format(path))
+            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
         except TypeError:
-            LOGGER.warning("Error reading file: {0}".format(path))
+            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
         return None
 
     # Subclassed to iterate over items
@@ -172,7 +174,7 @@ class DotNetSphinxMapper(SphinxMapperBase):
         try:
             cls = obj_map[data["type"].lower()]
         except KeyError:
-            LOGGER.warning("Unknown type: %s" % data)
+            LOGGER.warning("Unknown type: %s" % data, type="autoapi")
         else:
             obj = cls(
                 data, jinja_env=self.jinja_env, app=self.app, options=options, **kwargs

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -104,10 +104,13 @@ class DotNetSphinxMapper(SphinxMapperBase):
                 )
                 _, error_output = proc.communicate()
                 if error_output:
-                    LOGGER.warning(error_output, type="autoapi")
+                    LOGGER.warning(error_output, type="autoapi", subtype="not_readable")
             except (OSError, subprocess.CalledProcessError):
                 LOGGER.warning(
-                    "Error generating metadata", exc_info=True, type="autoapi"
+                    "Error generating metadata",
+                    exc_info=True,
+                    type="autoapi",
+                    subtype="metadata_generation",
                 )
                 if raise_error:
                     raise ExtensionError(
@@ -133,9 +136,17 @@ class DotNetSphinxMapper(SphinxMapperBase):
                 parsed_data = yaml.safe_load(handle)
                 return parsed_data
         except IOError:
-            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
+            LOGGER.warning(
+                "Error reading file: {0}".format(path),
+                type="autoapi",
+                subtype="not_readable",
+            )
         except TypeError:
-            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
+            LOGGER.warning(
+                "Error reading file: {0}".format(path),
+                type="autoapi",
+                subtype="not_readable",
+            )
         return None
 
     # Subclassed to iterate over items
@@ -174,7 +185,9 @@ class DotNetSphinxMapper(SphinxMapperBase):
         try:
             cls = obj_map[data["type"].lower()]
         except KeyError:
-            LOGGER.warning("Unknown type: %s" % data, type="autoapi")
+            LOGGER.warning(
+                "Unknown type: %s" % data, type="autoapi", subtype="create_class"
+            )
         else:
             obj = cls(
                 data, jinja_env=self.jinja_env, app=self.app, options=options, **kwargs

--- a/autoapi/mappers/dotnet.py
+++ b/autoapi/mappers/dotnet.py
@@ -185,9 +185,8 @@ class DotNetSphinxMapper(SphinxMapperBase):
         try:
             cls = obj_map[data["type"].lower()]
         except KeyError:
-            LOGGER.warning(
-                "Unknown type: %s" % data, type="autoapi", subtype="create_class"
-            )
+            # this warning intentionally has no (sub-)type
+            LOGGER.warning("Unknown type: %s" % data)
         else:
             obj = cls(
                 data, jinja_env=self.jinja_env, app=self.app, options=options, **kwargs

--- a/autoapi/mappers/go.py
+++ b/autoapi/mappers/go.py
@@ -54,9 +54,17 @@ class GoSphinxMapper(SphinxMapperBase):
             parsed_data = json.loads(subprocess.check_output(parser_command))
             return parsed_data
         except IOError:
-            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
+            LOGGER.warning(
+                "Error reading file: {0}".format(path),
+                type="autoapi",
+                subtype="not_readable",
+            )
         except TypeError:
-            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
+            LOGGER.warning(
+                "Error reading file: {0}".format(path),
+                type="autoapi",
+                subtype="not_readable",
+            )
         return None
 
     def create_class(self, data, options=None, **kwargs):
@@ -83,7 +91,9 @@ class GoSphinxMapper(SphinxMapperBase):
             else:
                 cls = obj_map[data["type"]]
         except KeyError:
-            LOGGER.warning("Unknown Type: %s" % data, type="autoapi")
+            LOGGER.warning(
+                "Unknown Type: %s" % data, type="autoapi", subtype="create_class"
+            )
         else:
             if cls.inverted_names and "names" in data:
                 # Handle types that have reversed names parameter

--- a/autoapi/mappers/go.py
+++ b/autoapi/mappers/go.py
@@ -91,9 +91,8 @@ class GoSphinxMapper(SphinxMapperBase):
             else:
                 cls = obj_map[data["type"]]
         except KeyError:
-            LOGGER.warning(
-                "Unknown Type: %s" % data, type="autoapi", subtype="create_class"
-            )
+            # this warning intentionally has no (sub-)type
+            LOGGER.warning("Unknown type: %s" % data)
         else:
             if cls.inverted_names and "names" in data:
                 # Handle types that have reversed names parameter

--- a/autoapi/mappers/go.py
+++ b/autoapi/mappers/go.py
@@ -54,9 +54,9 @@ class GoSphinxMapper(SphinxMapperBase):
             parsed_data = json.loads(subprocess.check_output(parser_command))
             return parsed_data
         except IOError:
-            LOGGER.warning("Error reading file: {0}".format(path))
+            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
         except TypeError:
-            LOGGER.warning("Error reading file: {0}".format(path))
+            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
         return None
 
     def create_class(self, data, options=None, **kwargs):
@@ -83,7 +83,7 @@ class GoSphinxMapper(SphinxMapperBase):
             else:
                 cls = obj_map[data["type"]]
         except KeyError:
-            LOGGER.warning("Unknown Type: %s" % data)
+            LOGGER.warning("Unknown Type: %s" % data, type="autoapi")
         else:
             if cls.inverted_names and "names" in data:
                 # Handle types that have reversed names parameter

--- a/autoapi/mappers/javascript.py
+++ b/autoapi/mappers/javascript.py
@@ -79,9 +79,8 @@ class JavaScriptSphinxMapper(SphinxMapperBase):
         try:
             cls = obj_map[data["kind"]]
         except (KeyError, TypeError):
-            LOGGER.warning(
-                "Unknown Type: %s" % data, type="autoapi", subtype="create_class"
-            )
+            # this warning intentionally has no (sub-)type
+            LOGGER.warning("Unknown type: %s" % data)
         else:
             # Recurse for children
             obj = cls(data, jinja_env=self.jinja_env, app=self.app)

--- a/autoapi/mappers/javascript.py
+++ b/autoapi/mappers/javascript.py
@@ -34,9 +34,17 @@ class JavaScriptSphinxMapper(SphinxMapperBase):
             parsed_data = json.loads(subprocess.check_output([subcmd, "-X", path]))
             return parsed_data
         except IOError:
-            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
+            LOGGER.warning(
+                "Error reading file: {0}".format(path),
+                type="autoapi",
+                subtype="not_readable",
+            )
         except TypeError:
-            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
+            LOGGER.warning(
+                "Error reading file: {0}".format(path),
+                type="autoapi",
+                subtype="not_readable",
+            )
         return None
 
     # Subclassed to iterate over items
@@ -71,7 +79,9 @@ class JavaScriptSphinxMapper(SphinxMapperBase):
         try:
             cls = obj_map[data["kind"]]
         except (KeyError, TypeError):
-            LOGGER.warning("Unknown Type: %s" % data, type="autoapi")
+            LOGGER.warning(
+                "Unknown Type: %s" % data, type="autoapi", subtype="create_class"
+            )
         else:
             # Recurse for children
             obj = cls(data, jinja_env=self.jinja_env, app=self.app)

--- a/autoapi/mappers/javascript.py
+++ b/autoapi/mappers/javascript.py
@@ -34,9 +34,9 @@ class JavaScriptSphinxMapper(SphinxMapperBase):
             parsed_data = json.loads(subprocess.check_output([subcmd, "-X", path]))
             return parsed_data
         except IOError:
-            LOGGER.warning("Error reading file: {0}".format(path))
+            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
         except TypeError:
-            LOGGER.warning("Error reading file: {0}".format(path))
+            LOGGER.warning("Error reading file: {0}".format(path), type="autoapi")
         return None
 
     # Subclassed to iterate over items
@@ -71,7 +71,7 @@ class JavaScriptSphinxMapper(SphinxMapperBase):
         try:
             cls = obj_map[data["kind"]]
         except (KeyError, TypeError):
-            LOGGER.warning("Unknown Type: %s" % data)
+            LOGGER.warning("Unknown Type: %s" % data, type="autoapi")
         else:
             # Recurse for children
             obj = cls(data, jinja_env=self.jinja_env, app=self.app)

--- a/autoapi/mappers/python/mapper.py
+++ b/autoapi/mappers/python/mapper.py
@@ -52,7 +52,7 @@ def _expand_wildcard_placeholder(original_module, originals_map, placeholder):
                 msg = "Invalid __all__ entry {0} in {1}".format(
                     name, original_module["name"]
                 )
-                LOGGER.warning(msg, type="autoapi")
+                LOGGER.warning(msg, type="autoapi", subtype="python_import_resolution")
                 continue
 
             originals.append(originals_map[name])
@@ -107,7 +107,7 @@ def _resolve_module_placeholders(modules, module_name, visit_path, resolved):
             msg = "Cannot resolve cyclic import: {0}, {1}".format(
                 ", ".join(visit_path), imported_from
             )
-            LOGGER.warning(msg, type="autoapi")
+            LOGGER.warning(msg, type="autoapi", subtype="python_import_resolution")
             module["children"].remove(child)
             children.pop(child["name"])
             continue
@@ -116,7 +116,7 @@ def _resolve_module_placeholders(modules, module_name, visit_path, resolved):
             msg = "Cannot resolve import of unknown module {0} in {1}".format(
                 imported_from, module_name
             )
-            LOGGER.warning(msg, type="autoapi")
+            LOGGER.warning(msg, type="autoapi", subtype="python_import_resolution")
             module["children"].remove(child)
             children.pop(child["name"])
             continue
@@ -144,7 +144,7 @@ def _resolve_module_placeholders(modules, module_name, visit_path, resolved):
             msg = "Cannot resolve import of {0} in {1}".format(
                 child["original_path"], module_name
             )
-            LOGGER.warning(msg, type="autoapi")
+            LOGGER.warning(msg, type="autoapi", subtype="python_import_resolution")
             module["children"].remove(child)
             children.pop(child["name"])
             continue
@@ -319,7 +319,11 @@ class PythonSphinxMapper(SphinxMapperBase):
             return parsed_data
         except (IOError, TypeError, ImportError):
             LOGGER.debug("Reason:", exc_info=True)
-            LOGGER.warning("Unable to read file: {0}".format(path), type="autoapi")
+            LOGGER.warning(
+                "Unable to read file: {0}".format(path),
+                type="autoapi",
+                subtype="not_readable",
+            )
         return None
 
     def _resolve_placeholders(self):
@@ -359,7 +363,11 @@ class PythonSphinxMapper(SphinxMapperBase):
         try:
             cls = self._OBJ_MAP[data["type"]]
         except KeyError:
-            LOGGER.warning("Unknown type: %s" % data["type"], type="autoapi")
+            LOGGER.warning(
+                "Unknown type: %s" % data["type"],
+                type="autoapi",
+                subtype="create_class",
+            )
         else:
             obj = cls(
                 data,

--- a/autoapi/mappers/python/mapper.py
+++ b/autoapi/mappers/python/mapper.py
@@ -52,7 +52,7 @@ def _expand_wildcard_placeholder(original_module, originals_map, placeholder):
                 msg = "Invalid __all__ entry {0} in {1}".format(
                     name, original_module["name"]
                 )
-                LOGGER.warning(msg)
+                LOGGER.warning(msg, type="autoapi")
                 continue
 
             originals.append(originals_map[name])
@@ -107,7 +107,7 @@ def _resolve_module_placeholders(modules, module_name, visit_path, resolved):
             msg = "Cannot resolve cyclic import: {0}, {1}".format(
                 ", ".join(visit_path), imported_from
             )
-            LOGGER.warning(msg)
+            LOGGER.warning(msg, type="autoapi")
             module["children"].remove(child)
             children.pop(child["name"])
             continue
@@ -116,7 +116,7 @@ def _resolve_module_placeholders(modules, module_name, visit_path, resolved):
             msg = "Cannot resolve import of unknown module {0} in {1}".format(
                 imported_from, module_name
             )
-            LOGGER.warning(msg)
+            LOGGER.warning(msg, type="autoapi")
             module["children"].remove(child)
             children.pop(child["name"])
             continue
@@ -144,7 +144,7 @@ def _resolve_module_placeholders(modules, module_name, visit_path, resolved):
             msg = "Cannot resolve import of {0} in {1}".format(
                 child["original_path"], module_name
             )
-            LOGGER.warning(msg)
+            LOGGER.warning(msg, type="autoapi")
             module["children"].remove(child)
             children.pop(child["name"])
             continue
@@ -318,8 +318,8 @@ class PythonSphinxMapper(SphinxMapperBase):
                 parsed_data = Parser().parse_file(path)
             return parsed_data
         except (IOError, TypeError, ImportError):
-            LOGGER.warning("Unable to read file: {0}".format(path))
             LOGGER.debug("Reason:", exc_info=True)
+            LOGGER.warning("Unable to read file: {0}".format(path), type="autoapi")
         return None
 
     def _resolve_placeholders(self):
@@ -359,7 +359,7 @@ class PythonSphinxMapper(SphinxMapperBase):
         try:
             cls = self._OBJ_MAP[data["type"]]
         except KeyError:
-            LOGGER.warning("Unknown type: %s" % data["type"])
+            LOGGER.warning("Unknown type: %s" % data["type"], type="autoapi")
         else:
             obj = cls(
                 data,

--- a/autoapi/mappers/python/mapper.py
+++ b/autoapi/mappers/python/mapper.py
@@ -363,11 +363,8 @@ class PythonSphinxMapper(SphinxMapperBase):
         try:
             cls = self._OBJ_MAP[data["type"]]
         except KeyError:
-            LOGGER.warning(
-                "Unknown type: %s" % data["type"],
-                type="autoapi",
-                subtype="create_class",
-            )
+            # this warning intentionally has no (sub-)type
+            LOGGER.warning("Unknown type: %s" % data["type"])
         else:
             obj = cls(
                 data,

--- a/autoapi/toctree.py
+++ b/autoapi/toctree.py
@@ -91,7 +91,12 @@ def _get_toc_reference(node, toc, docname):
             ref_id = node.children[0].attributes["ids"][0]
             toc_reference = _find_toc_node(toc, ref_id, addnodes.desc)
         except (KeyError, IndexError):
-            LOGGER.warning("Invalid desc node", exc_info=True, type="autoapi")
+            LOGGER.warning(
+                "Invalid desc node",
+                exc_info=True,
+                type="autoapi",
+                subtype="toc_reference",
+            )
             toc_reference = None
 
     return toc_reference

--- a/autoapi/toctree.py
+++ b/autoapi/toctree.py
@@ -91,7 +91,7 @@ def _get_toc_reference(node, toc, docname):
             ref_id = node.children[0].attributes["ids"][0]
             toc_reference = _find_toc_node(toc, ref_id, addnodes.desc)
         except (KeyError, IndexError):
-            LOGGER.warning("Invalid desc node", exc_info=True)
+            LOGGER.warning("Invalid desc node", exc_info=True, type="autoapi")
             toc_reference = None
 
     return toc_reference

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -276,3 +276,35 @@ Advanced Options
    Keeping files will also allow AutoAPI to use incremental builds.
    Providing none of the source files have changed,
    AutoAPI will skip parsing the source code and regenerating the API documentation.
+
+
+Suppressing Warnings
+---------------------
+
+.. confval:: suppress_warnings
+
+   This is a sphinx builtin option that enables the granular filtering of AutoAPI
+   generated warnings.
+
+   Items in the ``suppress_warnings`` list are of the format ``"type.subtype"`` where
+   ``".subtype"`` can be left out to cover all subtypes. To suppress all AutoAPI
+   warnings add the type ``"autoapi"`` to the list:
+
+   .. code-block:: python
+
+      suppress_warnings = ["autoapi"]
+
+   If narrower suppression is wanted, the available subtypes for AutoAPI are:
+
+     * python_import_resolution
+     * metadata_generation
+     * not_readable
+     * create_class
+     * toc_reference
+
+   So if all AutoAPI warnings concerning unreadable sources and failing Python imports should be
+   filtered, but all other warnings should not, the option would be
+
+   .. code-block:: python
+
+      suppress_warnings = ["autoapi.python_import_resolution", "autoapi.not_readable"]

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -299,7 +299,6 @@ Suppressing Warnings
      * python_import_resolution
      * metadata_generation
      * not_readable
-     * create_class
      * toc_reference
 
    So if all AutoAPI warnings concerning unreadable sources and failing Python imports should be

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -297,9 +297,14 @@ Suppressing Warnings
    If narrower suppression is wanted, the available subtypes for AutoAPI are:
 
      * python_import_resolution
+       Used if resolving references to objects in an imported module failed. Potential reasons
+       include cyclical imports and missing (parent) modules.
      * metadata_generation
+       (Dotnet only) Generating metadata for input files via docfx failed.
      * not_readable
+       Emitted if processing (opening, parsing, ...) an input file failed.
      * toc_reference
+       Used if a reference to an entry in a table of content cannot be resolved.
 
    So if all AutoAPI warnings concerning unreadable sources and failing Python imports should be
    filtered, but all other warnings should not, the option would be


### PR DESCRIPTION
This implements the proposal in https://github.com/readthedocs/sphinx-autoapi/issues/275

I'm not very sure about the subtypes. 

> "Unknown type" should possibly be an error so leave that one out for now. "Invalid all entry" could be invalid_sources.

Didn't come across either of those.