### PR TITLE
Generate rst files in src directory

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -105,7 +105,7 @@ def run_autoapi(app):  # pylint: disable=too-many-branches
             )
 
     normalized_root = os.path.normpath(
-        os.path.join(app.confdir, app.config.autoapi_root)
+        os.path.join(app.srcdir, app.config.autoapi_root)
     )
     url_root = os.path.join("/", app.config.autoapi_root)
 


### PR DESCRIPTION
Hello,

Most users keep their conf.py file and source code of documentation in one directory. In the Apache Airflow project, we share one configuration file between multiple documentation packages, but it causes problems because RST files are generated in a directory that is not recognized by sphinx.

In our case, the documentation structure looks like this.
```
├── apache-airflow
│   └── index.rst
├── apache-airflow-providers
│   └── index.rst
├── apache-airflow-providers-tableau
│   └── index.rst
├── apache-airflow-providers-telegram
│   └── index.rst
├── apache-airflow-providers-trino
│   └── index.rst
├── apache-airflow-providers-vertica
│   └── index.rst
├── apache-airflow-providers-yandex
│   └── index.rst
├── apache-airflow-providers-zendesk
│   └── index.rst
└── conf.py
```
As a workaround, I started configuring `autoapi_root` options to include a package name e.g.  `apache-airflow-providers-zendesk/_api`. This worked fine for a long time, but we now want to build the documentation in parallel, and this workaround is problematic, so I decided to fix the root of the problem.

We are testing this change in our project and it works well.
https://github.com/apache/airflow/pull/15176/files

CC: @potiuk @ashb 

