### PR TITLE
Added attribute summary table to python module template

### DIFF
--- a/autoapi/templates/python/module.rst
+++ b/autoapi/templates/python/module.rst
@@ -60,6 +60,7 @@ Submodules
 
 {% set visible_classes = visible_children|selectattr("type", "equalto", "class")|list %}
 {% set visible_functions = visible_children|selectattr("type", "equalto", "function")|list %}
+{% set visible_attributes = visible_children|selectattr("type", "equalto", "data")|list %}
 {% if "show-module-summary" in autoapi_options and (visible_classes or visible_functions) %}
 {% block classes scoped %}
 {% if visible_classes %}
@@ -85,6 +86,21 @@ Functions
 
 {% for function in visible_functions %}
    {{ function.id }}
+{% endfor %}
+
+
+{% endif %}
+{% endblock %}
+
+{% block attributes scoped %}
+{% if visible_attributes %}
+Attributes
+~~~~~~~~~~
+
+.. autoapisummary::
+
+{% for attribute in visible_attributes %}
+   {{ attribute.id }}
 {% endfor %}
 
 


### PR DESCRIPTION
Aims to fix #280. Tox passing (only 3.6 and 3.7, I didn't have 3.8 and 3.9)

However, it's a bit of a naive hack, so I suspect there's some additional stuff that needs doing here. So lemme know what else needs doing for this.