### PR TITLE
Add option autoapi_add_objects_to_toctree

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -193,7 +193,8 @@ def doctree_read(app, doctree):
     Inject AutoAPI into the TOC Tree dynamically.
     """
 
-    add_domain_to_toctree(app, doctree, app.env.docname)
+    if app.config.autoapi_add_objects_to_toctree:
+        add_domain_to_toctree(app, doctree, app.env.docname)
 
     if app.env.docname == "index":
         all_docs = set()
@@ -303,6 +304,7 @@ def setup(app):
     app.add_config_value("autoapi_python_class_content", "class", "html")
     app.add_config_value("autoapi_generate_api_docs", True, "html")
     app.add_config_value("autoapi_prepare_jinja_env", None, "html")
+    app.add_config_value("autoapi_add_objects_to_toctree", True, "html")
     app.add_autodocumenter(documenters.AutoapiFunctionDocumenter)
     app.add_autodocumenter(documenters.AutoapiPropertyDocumenter)
     app.add_autodocumenter(documenters.AutoapiDecoratorDocumenter)

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -151,6 +151,12 @@ Customisation Options
    and you will need to include the generated documentation
    in a TOC tree entry yourself.
 
+.. confval:: autoapi_add_objects_to_toctree
+
+   Default: ``True``
+
+   Whether to insert a TOC tree entry for each object (class, function, etc.).
+
 .. confval:: autoapi_python_class_content
 
    Default: ``class``


### PR DESCRIPTION
Add an option such that the automatic addition of objects to the toctree can be disabled by the user.

It's a nice feature, but is in a sense orthogonal to the goal of extracting documentation from source code.