### PR TITLE
Fix class args formatting when no __init__

### DIFF
--- a/autoapi/mappers/python/objects.py
+++ b/autoapi/mappers/python/objects.py
@@ -362,6 +362,8 @@ class PythonClass(PythonPythonMapper):
         constructor = self.constructor
         if constructor:
             args = constructor.args
+        else:
+            args = ''
 
         if args.startswith("self"):
             args = args[4:].lstrip(",").lstrip()


### PR DESCRIPTION
When documenting a class which has no ``__init__`` method there seems to be a missing initialization, resulting in the warning ``'list' object has no attribute 'startswith'``.
Can be reproduced with [autoapiTest.tar.gz](https://github.com/readthedocs/sphinx-autoapi/files/6580359/autoapiTest.tar.gz).