### PR TITLE
A set fixed signature length in summaries

### DIFF
--- a/autoapi/directives.py
+++ b/autoapi/directives.py
@@ -3,7 +3,7 @@
 from docutils.parsers.rst import Directive
 from docutils import nodes
 
-from sphinx.ext.autosummary import Autosummary
+from sphinx.ext.autosummary import Autosummary, mangle_signature
 from sphinx.util.nodes import nested_parse_with_titles
 
 from .mappers.python.objects import PythonFunction
@@ -16,6 +16,7 @@ class AutoapiSummary(Autosummary):  # pylint: disable=too-few-public-methods
         items = []
         env = self.state.document.settings.env
         all_objects = env.autoapi_all_objects
+        max_item_chars = 60
 
         for name in names:
             obj = all_objects[name]
@@ -28,6 +29,10 @@ class AutoapiSummary(Autosummary):  # pylint: disable=too-few-public-methods
                         sig += " \u2192 {}".format(obj.return_annotation)
             else:
                 sig = ""
+
+            if sig:
+                max_sig_chars = max(10, max_item_chars - len(obj.short_name))
+                sig = mangle_signature(sig, max_chars=max_sig_chars)
 
             item = (obj.short_name, sig, obj.summary, obj.id)
             items.append(item)

--- a/tests/python/pyexample/example/example.py
+++ b/tests/python/pyexample/example/example.py
@@ -128,3 +128,19 @@ class MultilineOne(One):
 
 class Two(One):
     """Two."""
+
+
+def fn_with_long_sig(
+    this,
+    *,
+    function=None,
+    has=True,
+    quite=True,
+    a,
+    long,
+    signature,
+    many,
+    keyword,
+    arguments
+):
+    """A function with a long signature."""

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -126,6 +126,33 @@ class TestSimpleModule:
 
         assert "Bases:" in example_file
 
+    def test_long_signature(self):
+        example_path = "_build/text/autoapi/example/index.txt"
+        with io.open(example_path, encoding="utf8") as example_handle:
+            example_file = example_handle.read()
+
+        summary_row = """
++------------+--------------------------------------------------------------------------------------------+
+| "fn_with_  | A function with a long signature.                                                          |
+| long_sig"  |                                                                                            |
+| (this, *[, |                                                                                            |
+| function,  |                                                                                            |
+| has,       |                                                                                            |
+| quite])    |                                                                                            |
++------------+--------------------------------------------------------------------------------------------+
+        """.strip()
+        assert summary_row in example_file
+
+        # Check length of truncated signature
+        parts = []
+        for line in summary_row.splitlines()[1:-1]:
+            part = line.split("|")[1].strip()
+            if part.endswith(","):
+                part += " "
+            parts.append(part)
+        sig_summary = "".join(parts)
+        assert len(sig_summary) <= 60
+
 
 class TestMovedConfPy(TestSimpleModule):
     @pytest.fixture(autouse=True, scope="class")


### PR DESCRIPTION
Use the Sphinx autosummary machinery ([`mangle_signature`](https://github.com/sphinx-doc/sphinx/blob/f42d8f7df6b41d257ca9583a9113df26d04b3c76/sphinx/ext/autosummary/__init__.py#L481)) to shorten the signatures, like done in [`Autosummary.get_items`](https://github.com/sphinx-doc/sphinx/blob/f42d8f7df6b41d257ca9583a9113df26d04b3c76/sphinx/ext/autosummary/__init__.py#L329).

Fixes #278 