### PR TITLE
Fix keyerror:  0

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -159,7 +159,7 @@ def run_autoapi(app):  # pylint: disable=too-many-branches
         out_suffix = ".txt"
     else:
         # Fallback to first suffix listed
-        out_suffix = app.config.source_suffix[0]
+        out_suffix = next(iter(app.config.source_suffix))
 
     if sphinx_mapper_obj.load(
         patterns=file_patterns, dirs=normalised_dirs, ignore=ignore_patterns

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -921,3 +921,13 @@ def test_no_files_found(builder):
         builder("pyemptyexample")
 
     assert os.path.dirname(__file__) in str(exc_info.value)
+
+
+class TestMdSource:
+    @pytest.fixture(autouse=True, scope="class")
+    def built(self, builder):
+        builder(
+            "pyexample",
+            warningiserror=True,
+            confoverrides={"source_suffix": ["md"]},
+        )


### PR DESCRIPTION
Setting `source_suffix = ".md"` led to the following cryptic error output:

    Handler <function run_autoapi at 0x10841fc10> for event 'builder-inited' threw an exception (exception: 0)

This issue was that `app.config.source_suffix` is an `OrderedDict` object, which cannot be subscripted
using `[0]`, etc. Instead, use `next(iter(...))` to get the first element of the dictionary.