### PR TITLE
Mark exteneion as parallel_read_safe

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -323,6 +323,6 @@ def setup(app):
     app.add_directive("autoapi-inheritance-diagram", AutoapiInheritanceDiagram)
 
     return {
-        "parallel_read_safe": False,
+        "parallel_read_safe": True,
         "parallel_write_safe": True,
     }


### PR DESCRIPTION
#222 added this, but in the release prep for 1.5.0 https://github.com/readthedocs/sphinx-autoapi/commit/0667de40376fc16c3c17febf28951527cbaaff8a it was set back to False.

I have manually tested this change on the apache-airflow docs with `-j auto` and it works (now?) so I'm not sure if there was a problem with parallel reads, or it was a mistake to set it back to False