### PR TITLE
Allow redefing functions

### DIFF
--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -131,3 +131,29 @@ class TestPythonParser:
         """
         data = self.parse(source)[0]
         assert data["name"] == "COLOUR"
+
+    def test_allow_redef(self):
+        """Allow redefing variables."""
+        source = """
+        variable = "value"
+        if True:
+            variable = "value2"
+        """
+        # We need `Model` node here, not statement.
+        node = astroid.extract_node(source)
+        data = Parser().parse(node.parent)["children"]
+        assert len(data) == 1
+        assert data[0]["value"] == "value2"
+
+    def test_ignore_failing_statements(self):
+        """Ignore redef if statement failing."""
+        source = """
+        variable = "value"
+        if False:
+            variable = "value2"
+        """
+        # We need `Model` node here, not statement.
+        node = astroid.extract_node(source)
+        data = Parser().parse(node.parent)["children"]
+        assert len(data) == 1
+        assert data[0]["value"] == "value"


### PR DESCRIPTION
Fixes #335

WARN: This will cause those `pylint` warnings:
```
autoapi\mappers\python\parser.py:275:0: C0301: Line too long (109/100) (line-too-long)
autoapi\mappers\python\parser.py:251:41: R0123: Comparison to literal (literal-comparison)
autoapi\mappers\python\parser.py:271:0: R0913: Too many arguments (6/5) (too-many-arguments)
```
Also it will broke this tests:
```
FAILED tests/python/test_pyintegration.py::TestPy3Module::test_overload - assert 'overloaded_func(a: float' in '"exam...
FAILED tests/python/test_pyintegration.py::test_py3_hiding_undoc_overloaded_members - assert 'overloaded_func' in '"e...
```
I don't know how to fix this, and very tired from debugging. 