### PR TITLE
Mention data's types and values in correct place

### DIFF
--- a/autoapi/templates/python/data.rst
+++ b/autoapi/templates/python/data.rst
@@ -1,11 +1,11 @@
 {% if obj.display %}
 .. py:{{ obj.type }}:: {{ obj.name }}
-   {%+ if obj.value is not none or obj.annotation is not none -%}
-   :annotation:
-        {%- if obj.annotation %} :{{ obj.annotation }}
-        {%- endif %}
-        {%- if obj.value is not none %} = {%
-            if obj.value is string and obj.value.splitlines()|count > 1 -%}
+   {%+ if obj.annotation is not none -%}
+   :type: {%- if obj.annotation %} {{ obj.annotation }}{%- endif %}
+   {%+ endif %}
+   {%- if obj.value is not none %}
+
+   :value: {% if obj.value is string and obj.value.splitlines()|count > 1 -%}
                 Multiline-String
 
     .. raw:: html
@@ -24,7 +24,6 @@
             {%- else -%}
                 {{ obj.value|string|truncate(100) }}
             {%- endif %}
-        {%- endif %}
     {% endif %}
 
 


### PR DESCRIPTION
So type hints can be correctly parsed and loaded.

For example, now intersphinx will create link to `str`.