### PR TITLE
Don't force member sort order to alphabetic

### DIFF
--- a/autoapi/documenters.py
+++ b/autoapi/documenters.py
@@ -79,7 +79,7 @@ class AutoapiDocumenter(autodoc.Documenter):
         elif not self.options.inherited_members:
             children = (child for child in children if not child[1].inherited)
 
-        return False, sorted(children)
+        return False, children
 
 
 class _AutoapiDocstringSignatureMixin:  # pylint: disable=too-few-public-methods

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -975,3 +975,29 @@ class TestMdSource:
             warningiserror=True,
             confoverrides={"source_suffix": ["md"]},
         )
+
+
+class TestMemberOrder:
+    @pytest.fixture(autouse=True, scope="class")
+    def built(self, builder):
+        builder(
+            "pyexample",
+            warningiserror=True,
+            confoverrides={
+                "suppress_warnings": ["app"],
+                "autodoc_member_order": "bysource",
+            },
+        )
+
+    def test_line_number_order(self):
+        example_path = "_build/text/manualapi.txt"
+        with io.open(example_path, encoding="utf8") as example_handle:
+            lines = example_handle.readlines()
+
+        method_tricky_pos = lines.index(
+            "   method_tricky(foo=None, bar=dict(foo=1, bar=2))\n"
+        )
+        method_sphinx_docs_pos = lines.index("   method_sphinx_docs(foo, bar=0)\n")
+
+        # method_tricky is defined in the source before method_sphinx_docs
+        assert method_tricky_pos < method_sphinx_docs_pos


### PR DESCRIPTION
sphinx.ext.autodoc has a `member-order:` directive, and this powers the `sort_member` function[[1]] to sort object members for us -- by removing the `sorted` call ourselves we allow the "bysource" mode to work: with the `sorted` call, since we don't set `self.analyzer` no extra sorting happens, so the `:member-order: bysource` setting has no effect.

The default sort mode for autodoc is alphabetical, so this should result in no changes to docs by default

[1]: https://github.com/sphinx-doc/sphinx/blob/984416247370a87ad947d89f334a8ce2d8ea6558/sphinx/ext/autodoc/__init__.py#L816-L836