### PR TITLE
Fix getting 'orig_path' for 'viewcode_follow_imported'

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -264,7 +264,13 @@ def viewcode_follow_imported(app, modname, attribute):
     if fullname not in all_objects:
         return None
 
-    orig_path = all_objects[fullname].obj.get("original_path", "")
+    if all_objects[fullname].obj.get("type") == 'method':
+        fullname = fullname[:fullname.rfind('.')]
+        attribute = attribute[:attribute.rfind('.')]
+    while all_objects[fullname].obj.get("original_path", "") != "":
+        fullname = all_objects[fullname].obj.get("original_path")
+
+    orig_path = fullname
     if orig_path.endswith(attribute):
         return orig_path[: -len(attribute) - 1]
 


### PR DESCRIPTION
## Motivation

When I use `autoapi` to build aAPI docs and I want to use `viewcode`  to add `source code link` in docs, I meet this problem.
The built doc is https://mmediting.readthedocs.io/en/dev-1.x/  . I find that when an object's (class, function, or method) directory level is lower more than 2 levels than the directory level of the current API doc, the source link of this object will lost. For example: 

The path of `class AOTBlockNeck` is `mmedit.models.editors.aotgan.aot_neck.AOTBlockNeck` and the path of the current doc is `mmedit.models.editors`. The source link will be lost.
![image](https://user-images.githubusercontent.com/49083766/218040207-08741ed8-8e81-4fe2-93a1-1b2c6718733a.png)
But when the path of the current doc is `mmedit.models.editors.aotgan`, the source link will be built.
![image](https://user-images.githubusercontent.com/49083766/218041038-66cdc062-e60a-4dd2-bf96-63a9c5ca0495.png)

And another example of the `method` object: the path of 'method add_datasample' is `mmedit.visualization.concat_visualizer.ConcatImageVisualizer.add_datasample`, the path of `class ConcatImageVisualizer` is `mmedit.visualization.concat_visualizer.ConcatImageVisualizer`, and the path of the current doc is `mmedit.visualization`. 2 levels gap of path gets the source link, but 3 levels gap doesn't.
![image](https://user-images.githubusercontent.com/49083766/218041400-ccb1628b-a610-4b8c-9a76-66c9dd780ab8.png)



## Modification

I think the reason is that some objects don't get their correct path of source code file. Related codes are in autoapi/extension.py/viewcode_follow_imported. After modification, We will iteratively find the `original_path` of  `original_path`, until the final `original_path` is a real source code file.

This is test results:
![image](https://user-images.githubusercontent.com/49083766/218043605-1a12298f-48fe-4bd3-81a2-2b233f12e28b.png)
![image](https://user-images.githubusercontent.com/49083766/218043729-d117ad1e-62f5-416d-8801-1e83ba2b750e.png)
