### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/docs/changes/375.misc.rst
+++ b/docs/changes/375.misc.rst
@@ -1,0 +1,1 @@
+Remove redundant dependency on wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=46.4.0", "wheel"]
+requires = ["setuptools>=46.4.0"]
 build-backend = "setuptools.build_meta"
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a