### PR TITLE
Catch all exceptions when reading files

### DIFF
--- a/autoapi/mappers/python/mapper.py
+++ b/autoapi/mappers/python/mapper.py
@@ -322,8 +322,8 @@ class PythonSphinxMapper(SphinxMapperBase):
             else:
                 parsed_data = Parser().parse_file(path)
             return parsed_data
-        except (IOError, TypeError, ImportError):
-            LOGGER.debug("Reason:", exc_info=True)
+        except Exception as e:
+            LOGGER.debug("Reason: Received Exception of type " + str(type(e)) + ": " + str(e), exc_info=True)
             LOGGER.warning(
                 "Unable to read file: {0}".format(path),
                 type="autoapi",


### PR DESCRIPTION
Importing a file with this content:
```python
from typing import TypedDict
MyDict = TypedDict("MyDict", {'badField': List[], 'goodField': int})
```
Results in an extremely unhelpful error message that does not mention the offending file:
```
Extension error (autoapi.extension):
Handler <function run_autoapi at 0x7fbc8d1be3a0> for event 'builder-inited' threw an exception (exception: Parsing Python code failed:
invalid syntax (<unknown>, line 2))
```
This change fixes the behavior.

For the record, the `Exception` that was not caught was of type `astroid.exceptions.AstroidSyntaxError`.