### PR TITLE
fix: Unknown type: placeholder bug #180

### DIFF
--- a/autoapi/mappers/python/mapper.py
+++ b/autoapi/mappers/python/mapper.py
@@ -331,7 +331,10 @@ class PythonSphinxMapper(SphinxMapperBase):
         modules = {}
         for module in self.paths.values():
             children = {child["name"]: child for child in module["children"]}
-            modules[module["name"]] = (module, children)
+            if module["name"] not in modules:
+                modules[module["name"]] = (module, children)
+            else:  # Update the module if it already exists
+                modules[module["name"]][1].update(children)
 
         resolved = set()
         for module_name in modules:


### PR DESCRIPTION
This PR adds a fix for the `Unknown type: placeholder` that was given in #180. See [this comment](https://github.com/readthedocs/sphinx-autoapi/issues/180#issuecomment-1589208233).