### PR TITLE
Ensure `tooltip` is always a `str`

### DIFF
--- a/autoapi/inheritance_diagrams.py
+++ b/autoapi/inheritance_diagrams.py
@@ -86,7 +86,7 @@ class _AutoapiInheritanceGraph(sphinx.ext.inheritance_diagram.InheritanceGraph):
                     tooltip = '"%s"' % doc.replace('"', '\\"')
 
             baselist = []
-            all_classes[cls] = (nodename, fullname, baselist, tooltip)
+            all_classes[cls] = (nodename, fullname, baselist, tooltip or "")
 
             if fullname in top_classes:
                 return

--- a/docs/changes/396.str-tooltip.bugfix
+++ b/docs/changes/396.str-tooltip.bugfix
@@ -1,0 +1,1 @@
+Ensure `tooltip` is always a `str`.


### PR DESCRIPTION
Resolves https://github.com/readthedocs/sphinx-autoapi/issues/396