### PR TITLE
Replace usage of deprecated astroid.NodeNG.doc in inheritance_diagram

### DIFF
--- a/autoapi/inheritance_diagrams.py
+++ b/autoapi/inheritance_diagrams.py
@@ -80,8 +80,8 @@ class _AutoapiInheritanceGraph(sphinx.ext.inheritance_diagram.InheritanceGraph):
             fullname = self.class_name(cls, 0, aliases)
 
             tooltip = None
-            if cls.doc:
-                doc = cls.doc.strip().split("\n")[0]
+            if cls.doc_node:
+                doc = cls.doc_node.value.strip().split("\n")[0]
                 if doc:
                     tooltip = '"%s"' % doc.replace('"', '\\"')
 

--- a/docs/changes/407.misc
+++ b/docs/changes/407.misc
@@ -1,0 +1,1 @@
+Replace usage of removed astroid.NodeNG.doc when building inheritance diagram

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ commands =
 [testenv:release_notes]
 deps =
     towncrier
+    importlib-resources<6  # pinned due to https://github.com/twisted/towncrier/issues/528
 commands =
     towncrier {posargs:check}
 


### PR DESCRIPTION
Alongside the unreleased changes in 0ba883a, this fixes #407.

