### PR TITLE
Preserve strings inside Literal type annotations

### DIFF
--- a/autoapi/mappers/python/astroid_utils.py
+++ b/autoapi/mappers/python/astroid_utils.py
@@ -416,7 +416,20 @@ def _resolve_annotation(annotation):
         # astroid.Index was removed in astroid v3
         if hasattr(astroid, "Index") and isinstance(slice_node, astroid.Index):
             slice_node = slice_node.value
-        if isinstance(slice_node, astroid.Tuple):
+        if value == "Literal":
+            if isinstance(slice_node, astroid.Tuple):
+                elts = slice_node.elts
+            else:
+                elts = [slice_node]
+            slice_ = ", ".join(
+                (
+                    elt.as_string()
+                    if isinstance(elt, astroid.Const)
+                    else _resolve_annotation(elt)
+                )
+                for elt in elts
+            )
+        elif isinstance(slice_node, astroid.Tuple):
             slice_ = ", ".join(_resolve_annotation(elt) for elt in slice_node.elts)
         else:
             slice_ = _resolve_annotation(slice_node)

--- a/docs/changes/423.bugfix
+++ b/docs/changes/423.bugfix
@@ -1,0 +1,1 @@
+Preserve strings inside Literal type annotations

--- a/tests/test_astroid_utils.py
+++ b/tests/test_astroid_utils.py
@@ -209,6 +209,9 @@ class TestAstroidUtils:
             ),
             ("a: int, *args, b: str, **kwargs", "a: int, *args, b: str, **kwargs"),
             ("a: 'A'", "a: A"),
+            ("a: Literal[1]", "a: Literal[1]"),
+            ("a: Literal['x']", "a: Literal['x']"),
+            ("a: Literal['x', 'y', 'z']", "a: Literal['x', 'y', 'z']"),
         ],
     )
     def test_format_args(self, signature, expected):


### PR DESCRIPTION
Hello,

I really appreciate the work put into this extension. It's very easy to set up and to customize.

Currently, if one has a type annotation with [``Literal``](https://typing.readthedocs.io/en/latest/spec/literal.html#literal-types), the strings inside are treated as if they were forward references, rather than constant strings.

Given this function:
```py
def func(arg: Literal['one', 'two', 'three']) -> str:
    return arg
```

The generated documentation is this:
```py
func(arg: Literal[one, two, three]) → str
```

Rather than what would be expected:
```py
func(arg: Literal['one', 'two', 'three']) → str
```

I changed `astroid_utils._resolve_annotation` to check if the subscript value is ``Literal`` and if so, return `.as_string()` for constants such as strings and bytes. I also added a few tests and a news fragment.