### PR TITLE
Replace usage of deprecated docutils.nodes.Node.traverse

### DIFF
--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -156,7 +156,7 @@ def doctree_read(app, doctree):
     if app.env.docname == "index":
         all_docs = set()
         insert = True
-        nodes = list(doctree.traverse(toctree))
+        nodes = list(doctree.findall(toctree))
         toc_entry = f"{app.config.autoapi_root}/index"
         add_entry = (
             nodes


### PR DESCRIPTION
Sphinx 6.1.0 (the lowest supported version) requires `docutils>=0.18`, which happens to be when `Node.findall` was introduced. This means we can use `Node.findall` without errors. Fixes GH-393 (which mistakenly mentioned astroid instead of docutils).