### PR TITLE
Add test and docs extra dependencies to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,5 @@
     },
 
     // Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install ."
+	"postCreateCommand": "pip3 install .[docs,test]"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ docs =
     furo
     sphinx
     sphinx_design
+test = tox
 
 [options.packages.find]
 include =


### PR DESCRIPTION
It's more convenient to have everything available in the devcontainer to build the autoapi docs or run tox for test directly after building the devcontainer.