### PR TITLE
Mark tests that use the network

### DIFF
--- a/docs/changes/462.misc.rst
+++ b/docs/changes/462.misc.rst
@@ -1,0 +1,1 @@
+Mark tests that use the network

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ disallow_untyped_defs = true
 # Ignore until astroid is typed (https://github.com/pylint-dev/astroid/issues/2060)
 warn_return_any = false
 
+[tool.pytest.ini_options]
+markers = [
+    "network: Tests that use network access.",
+]
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -657,6 +657,7 @@ class TestPositionalOnlyArgumentsModule:
         assert "f_no_cd(a: int, b: int, /, *, e: float, f: float)" in f_no_cd.text
 
 
+@pytest.mark.network
 @pytest.mark.skipif(
     sys.version_info < (3, 10), reason="Union pipe syntax requires Python >=3.10"
 )
@@ -700,6 +701,7 @@ class TestPipeUnionModule:
         assert links[1].text == "None"
 
 
+@pytest.mark.network
 @pytest.mark.skipif(
     sys.version_info < (3, 12), reason="PEP-695 support requires Python >=3.12"
 )


### PR DESCRIPTION
These two tests uses intersphinx, and the marker allows skipping them if there is no network available.