### PR TITLE
tox.ini: Upgrade towncrier

### DIFF
--- a/docs/changes/493.misc.rst
+++ b/docs/changes/493.misc.rst
@@ -1,0 +1,1 @@
+tox.ini: Upgrade towncrier

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,10 +34,10 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     astroid>=2.7;python_version<"3.12"
-    astroid>=3.0.0a1;python_version>="3.12"
+    astroid>=3.0.0;python_version>="3.12"
     Jinja2
     PyYAML
-    sphinx>=6.1.0
+    sphinx>=6.1.0,<8.1.0
     stdlib_list;python_version<"3.10"
 
 [options.extras_require]

--- a/tests/python/pyexample/example/example.py
+++ b/tests/python/pyexample/example/example.py
@@ -169,7 +169,7 @@ def fn_with_long_sig(
     signature,
     many,
     keyword,
-    arguments
+    arguments,
 ):
     """A function with a long signature."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,5 @@ commands =
 [testenv:release_notes]
 deps =
     towncrier
-    importlib-resources<6  # pinned due to https://github.com/twisted/towncrier/issues/528
 commands =
     towncrier {posargs:check}


### PR DESCRIPTION
Remove the unnecessary workaround for
* twisted/towncrier#528 (closed)