### PR TITLE
Newline before a property's doc string

### DIFF
--- a/autoapi/templates/python/property.rst
+++ b/autoapi/templates/python/property.rst
@@ -15,6 +15,7 @@
    {% endfor %}
 
    {% if obj.docstring %}
+
    {{ obj.docstring|indent(3) }}
    {% endif %}
 {% endif %}


### PR DESCRIPTION
Otherwise it renders incorrectly at least without a type.

```python
@property
def foo(self):
    """Foo's doc string"""
    pass
```