### PR TITLE
Fix adding incorrect attributes from __init__

### DIFF
--- a/autoapi/_parser.py
+++ b/autoapi/_parser.py
@@ -267,6 +267,23 @@ class Parser:
         if node.name == "__init__":
             for child in node.get_children():
                 if isinstance(child, (astroid.nodes.Assign, astroid.nodes.AnnAssign)):
+                    # Verify we are assigning to self.
+                    if isinstance(child, astroid.nodes.Assign):
+                        targets = child.targets
+                    else:
+                        targets = [child.target]
+
+                    target_ok = True
+                    for target in targets:
+                        if not isinstance(target, astroid.nodes.AssignAttr):
+                            target_ok = False
+                            break
+                        _object = target.expr
+                        if not isinstance(_object, astroid.nodes.Name) or _object.name != "self":
+                            target_ok = False
+                            break
+                    if not target_ok:
+                        continue
                     child_data = self._parse_assign(child)
                     result.extend(data for data in child_data)
 

--- a/tests/python/py3example/example/example.py
+++ b/tests/python/py3example/example/example.py
@@ -92,6 +92,12 @@ class A:
         self.instance_var: bool = True
         """This is an instance_var."""
 
+        self.subobject: object = object()
+        self.subobject.subobject_variable = 1
+
+        local_variable_typed: int = 0
+        local_variable_untyped = 2
+
     async def async_method(self, wait: bool) -> int:
         if wait:
             await asyncio.sleep(1)

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -458,6 +458,13 @@ class TestPy3Module:
 
         assert example_file.find(id="example.A.instance_var")
 
+        # Locals are excluded
+        assert not example_file.find(id="example.A.local_variable_typed")
+        assert not example_file.find(id="example.A.local_variable_untyped")
+
+        # Assignments to subobjects are excluded
+        assert not example_file.find(id="example.A.subobject_variable")
+
         global_a = example_file.find(id="example.global_a")
         assert global_a
         global_a_value = global_a.find_all(class_="property")


### PR DESCRIPTION
These cases in `__init__` are fixed:
* `local_variable : int = 1`
* `local_variable = 1`
* `self.foo.bar = 1` (Isn't .bar in the object.)

This assumes that the first parameter to `__init__` is called "self".