### PR TITLE
Make _need_to_load not assume that file ordering remained the same

### DIFF
--- a/autoapi/_mapper.py
+++ b/autoapi/_mapper.py
@@ -394,7 +394,9 @@ class Mapper:
         if self.app.env.config_status != sphinx.environment.CONFIG_OK:
             return True
 
-        return last_files != files or not last_mtime or last_mtime < this_mtime
+        return (
+            set(last_files) != set(files) or not last_mtime or last_mtime < this_mtime
+        )
 
     def _find_files(self, patterns, dirs, ignore):
         for dir_ in dirs:

--- a/docs/changes/502.misc.rst
+++ b/docs/changes/502.misc.rst
@@ -1,0 +1,1 @@
+Make _need_to_load not assume that file ordering remained the same


### PR DESCRIPTION
In Debian, we use disorderfs as part of checking reproducibility, and without this change test_caching failed:

https://salsa.debian.org/python-team/packages/sphinx-autoapi/-/jobs/6643761