### PR TITLE
Render typing_extensions.TypeAlias like other type aliases

### DIFF
--- a/autoapi/_astroid_utils.py
+++ b/autoapi/_astroid_utils.py
@@ -522,6 +522,8 @@ def _resolve_annotation(annotation: astroid.nodes.NodeNG) -> str:
 
     if resolved.startswith("typing."):
         return resolved[len("typing.") :]
+    if resolved.startswith("typing_extensions."):
+        return resolved[len("typing_extensions.") :]
 
     # Sphinx is capable of linking anything in the same module
     # without needing a fully qualified path.

--- a/autoapi/_objects.py
+++ b/autoapi/_objects.py
@@ -352,7 +352,11 @@ class PythonData(PythonObject):
         """
 
     def is_type_alias(self):
-        return self.annotation in ("TypeAlias", "typing.TypeAlias")
+        return self.annotation in (
+            "TypeAlias",
+            "typing.TypeAlias",
+            "typing_extensions.TypeAlias",
+        )
 
 
 class PythonAttribute(PythonData):

--- a/autoapi/_parser.py
+++ b/autoapi/_parser.py
@@ -90,7 +90,11 @@ class Parser:
         value_node = assign_value[1]
 
         annotation = _astroid_utils.get_assign_annotation(node)
-        if annotation in ("TypeAlias", "typing.TypeAlias"):
+        if annotation in (
+            "TypeAlias",
+            "typing.TypeAlias",
+            "typing_extensions.TypeAlias",
+        ):
             value = node.value.as_string()
         elif isinstance(
             value_node, astroid.nodes.ClassDef

--- a/tests/python/pep695/example/example.py
+++ b/tests/python/pep695/example/example.py
@@ -1,4 +1,8 @@
 from typing import TypeAlias
+import typing
+import typing_extensions
 
 MyTypeAliasA: TypeAlias = tuple[str, int]
 type MyTypeAliasB = tuple[str, int]
+MyTypeAliasC: typing.TypeAlias = tuple[str, int]
+MyTypeAliasD: typing_extensions.TypeAlias = tuple[str, int]

--- a/tests/python/test_pyintegration.py
+++ b/tests/python/test_pyintegration.py
@@ -756,6 +756,18 @@ class TestPEP695:
         value = properties[1].text
         assert value == " = tuple[str, int]"
 
+        alias = example_file.find(id="example.MyTypeAliasC")
+        properties = alias.find_all(class_="property")
+        assert len(properties) == 2
+        value = properties[1].text
+        assert value == " = tuple[str, int]"
+
+        alias = example_file.find(id="example.MyTypeAliasD")
+        properties = alias.find_all(class_="property")
+        assert len(properties) == 2
+        value = properties[1].text
+        assert value == " = tuple[str, int]"
+
 
 def test_napoleon_integration_loaded(builder, parse):
     confoverrides = {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Treat the `typing_extensions` module the same way as the `typing` module.

### Why should this Pull Request be merged?

Fixes #520 

### What testing has been done?

Ran `tox` on Windows. The tests passed (once I enabled symlinks for my local Git repo) but the `release_notes` env failed.