### PR TITLE
A user tool to debug visibility of objects

### DIFF
--- a/autoapi/_mapper.py
+++ b/autoapi/_mapper.py
@@ -30,6 +30,7 @@ from ._objects import (
     PythonData,
     PythonException,
     _trace_visibility,
+    HideReason,
 )
 from .settings import OWN_PAGE_LEVELS, TEMPLATE_DIR
 
@@ -45,12 +46,7 @@ LOGGER = sphinx.util.logging.getLogger(__name__)
 
 
 def _color_info(msg: str) -> None:
-    LOGGER.info(
-        colorize("bold", "[AutoAPI] ")
-        + colorize(
-            "darkgreen", msg
-        )
-    )
+    LOGGER.info(colorize("bold", "[AutoAPI] ") + colorize("darkgreen", msg))
 
 
 def _expand_wildcard_placeholder(original_module, originals_map, placeholder):
@@ -389,13 +385,6 @@ class Mapper:
         # Render Top Index
         top_level_index = os.path.join(self.dir_root, "index.rst")
 
-        modules = [obj for obj in self.all_objects.values()
-                   if obj.type == "module" and obj.docstring == ""]
-        if modules and "undoc-members" not in self.app.config.autoapi_options:
-            _color_info("The following modules have no top-level documentation, and so were skipped as undocumented:")
-            for m in modules:
-                _color_info(f"    {m.id}")
-
         pages = [obj for obj in self.objects_to_render.values() if obj.display]
         if not pages:
             msg = (
@@ -507,8 +496,12 @@ class Mapper:
                     and not obj["inherited_from"]["is_abstract"]
                     and module not in documented_modules
                 ):
-                    _trace_visibility(self.app, f"Hiding {obj['qual_name']} as determined to be Python standard Library (found as {obj['full_name']})", verbose=2)
-                    obj["hide"] = True
+                    _trace_visibility(
+                        self.app,
+                        f"Hiding {obj['qual_name']} as determined to be Python standard Library (found as {obj['full_name']})",
+                        verbose=2,
+                    )
+                    obj["hide_reason"] = HideReason.STD_LIBRARY
 
     def _resolve_placeholders(self):
         """Resolve objects that have been imported from elsewhere."""
@@ -527,19 +520,27 @@ class Mapper:
         for module in self.paths.values():
             if module["all"] is not None:
                 all_names = set(module["all"])
-                _trace_visibility(self.app, f"{module['full_name']}: Found __all__ =")
                 for n in all_names:
                     _trace_visibility(self.app, f"    {n}")
                 for child in module["children"]:
                     if child["qual_name"] not in all_names:
-                        _trace_visibility(self.app, f"Hiding {child['full_name']}, as {child['qual_name']} not in __all__")
-                        child["hide"] = True
+                        _trace_visibility(
+                            self.app,
+                            f"Hiding {child['full_name']}, as {child['qual_name']} not in __all__",
+                        )
+                        child["hide_reason"] = HideReason.NOT_IN_ALL
             elif module["type"] == "module":
-                _trace_visibility(self.app, f"Testing if any children of {module['full_name']} have already been documented")
+                _trace_visibility(
+                    self.app,
+                    f"Testing if any children of {module['full_name']} have already been documented",
+                )
                 for child in module["children"]:
                     if "original_path" in child:
-                        _trace_visibility(self.app, f"Hiding {child['full_name']} as documented at {child['original_path']}")
-                        child["hide"] = True
+                        _trace_visibility(
+                            self.app,
+                            f"Hiding {child['full_name']} as it appears to be in your public API at {child['original_path']}",
+                        )
+                        child["hide_reason"] = HideReason.NOT_PUBLIC
 
     def map(self, options=None):
         self._skip_if_stdlib()
@@ -583,17 +584,27 @@ class Mapper:
                 self.objects_to_render[obj.id] = obj
             else:
                 if obj.subpackages or obj.submodules:
-                    _trace_visibility(self.app, f"Not rendering the following as {obj.id} set to not display:", verbose=2)
+                    _trace_visibility(
+                        self.app,
+                        f"Not rendering the following as {obj.id} set to not display because object is {obj.hide_reason}",
+                        verbose=2,
+                    )
                 for module in itertools.chain(obj.subpackages, obj.submodules):
-                    _trace_visibility(self.app, f"    {module.obj['full_name']}", verbose=2)
-                    module.obj["hide"] = True
+                    _trace_visibility(
+                        self.app, f"    {module.obj['full_name']}", verbose=2
+                    )
+                    module.obj["hide_reason"] = HideReason.PARENT_HIDDEN
 
         def _inner(parent):
             for child in parent.children:
                 self.all_objects[child.id] = child
                 if not parent.display:
-                    _trace_visibility(self.app, f"Hiding {child.id} as parent {parent.id} will not be displayed", verbose=2)
-                    child.obj["hide"] = True
+                    _trace_visibility(
+                        self.app,
+                        f"Hiding {child.id} as parent {parent.id} will not be displayed",
+                        verbose=2,
+                    )
+                    child.obj["hide_reason"] = HideReason.PARENT_HIDDEN
 
                 if child.display and child.type in self.own_page_types:
                     self.objects_to_render[child.id] = child
@@ -602,6 +613,18 @@ class Mapper:
 
         for obj in list(self.all_objects.values()):
             _inner(obj)
+
+        modules = [
+            obj
+            for obj in self.all_objects.values()
+            if obj.type == "module" and obj.docstring == ""
+        ]
+        if modules and "undoc-members" not in self.app.config.autoapi_options:
+            _color_info(
+                "The following modules have no top-level documentation, and so were skipped as undocumented:"
+            )
+            for m in modules:
+                _color_info(f"    {m.id}")
 
     def create_class(self, data, options=None):
         """Create a class from the passed in data

--- a/autoapi/_objects.py
+++ b/autoapi/_objects.py
@@ -8,6 +8,7 @@ if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
     from backports.strenum import StrEnum
+
 from typing import List
 
 import sphinx

--- a/autoapi/_objects.py
+++ b/autoapi/_objects.py
@@ -279,11 +279,11 @@ class PythonObject:
             self._display_cache = self.hide_reason
             if self._display_cache != HideReason.NOT_HIDDEN:
                 _trace_visibility(
-                    self.app, f"Skipping {self.id} due to {self.hide_reason}"
+                    self.app, f"Skipping {self.id} due to {self._display_cache}"
                 )
-        else:
+        elif self._display_cache != HideReason.NOT_HIDDEN:
             _trace_visibility(
-                self.app, f"Skipping {self.id} due to {self.hide_reason}", verbose=2
+                self.app, f"Skipping {self.id} due to {self._display_cache}", verbose=2
             )
 
         return self._display_cache == HideReason.NOT_HIDDEN

--- a/autoapi/extension.py
+++ b/autoapi/extension.py
@@ -261,6 +261,7 @@ def setup(app):
     app.add_config_value("autoapi_generate_api_docs", True, "html")
     app.add_config_value("autoapi_prepare_jinja_env", None, "html")
     app.add_config_value("autoapi_own_page_level", "module", "html")
+    app.add_config_value("autoapi_verbose_visibility", 0, "html")
     app.add_autodocumenter(documenters.AutoapiFunctionDocumenter)
     app.add_autodocumenter(documenters.AutoapiPropertyDocumenter)
     app.add_autodocumenter(documenters.AutoapiDecoratorDocumenter)

--- a/docs/how_to.rst
+++ b/docs/how_to.rst
@@ -25,6 +25,7 @@ then that function is documented in both the submodule and the package.
     is not documented by default.
 
 However there are multiple options available for controlling what AutoAPI will document.
+If objects are unexpectedly missing, see :ref:`debug-visibility`.
 
 
 Set ``__all__``
@@ -113,6 +114,38 @@ so it should only be necessary when the other options do not give you
 the control the you need.
 You can learn how to customise the templates in the next section:
 :ref:`customise-templates`.
+
+
+.. _debug-visibility:
+
+How to Debug Visibility of Objects
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If objects that you expect to be documented are missing from the output,
+you can use the :confval:`autoapi_verbose_visibility` option to find out why.
+
+Set the option in your ``conf.py``:
+
+.. code-block:: python
+
+    autoapi_verbose_visibility = 1
+
+Then rebuild your documentation.
+AutoAPI will log each decision to hide an object,
+prefixed with ``[AutoAPI] [Visibility]``, along with the reason.
+Common reasons include:
+
+* **Undocumented member**: The object has no docstring
+  and ``undoc-members`` is not in :confval:`autoapi_options`.
+  Adding a docstring to the object (or to the module's ``__init__.py``) will make it visible.
+* **Private member**: The object name starts with ``_``
+  and ``private-members`` is not in :confval:`autoapi_options`.
+* **Not in __all__**: The object is in a package that defines ``__all__``
+  and the object is not listed there.
+* **Skipped by event handler**: An :event:`autoapi-skip-member` handler returned ``True``.
+
+For even more detail, set the option to ``2``
+to additionally see cache hits and per-module rendering information.
 
 
 .. _customise-templates:

--- a/docs/how_to.rst
+++ b/docs/how_to.rst
@@ -80,6 +80,14 @@ and hide your object definitions in private modules.
 As another example, you could remove ``undoc-members`` from :confval:`autoapi_options`
 and only add docstrings for the modules and other entities that you want to be documented.
 
+.. note::
+
+    This also applies to modules and packages.
+    If ``undoc-members`` is not in :confval:`autoapi_options`
+    and a package's ``__init__.py`` has no module-level docstring,
+    then the entire package will be excluded from the documentation.
+    Adding a docstring at the top of ``__init__.py`` is enough to make it visible.
+
 See :confval:`autoapi_options` for more information on how to use this option.
 
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -257,6 +257,26 @@ Advanced Options
    AutoAPI will skip parsing the source code and regenerating the API documentation.
 
 
+.. confval:: autoapi_verbose_visibility
+
+   Default: ``0``
+
+   Controls the verbosity of visibility-related log messages,
+   which explain why objects are included in or excluded from the generated documentation.
+   This is useful for debugging when expected objects are missing from the output.
+
+   * ``0``: No visibility logging (the default).
+   * ``1``: Log each decision to hide an object, including the reason
+     (e.g. undocumented member, private member, not in ``__all__``,
+     hidden by :event:`autoapi-skip-member`).
+   * ``2``: Additionally log cache hits and per-module rendering details.
+
+   Messages are prefixed with ``[AutoAPI] [Visibility]`` and emitted at the
+   ``INFO`` log level, so they appear in normal Sphinx output.
+
+   See :ref:`debug-visibility` for a guide on using this option.
+
+
 Suppressing Warnings
 ---------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,8 @@ filename = "CHANGELOG.rst"
 package = "autoapi"
 title_format = "v{version} ({project_date})"
 underlines = ["-", "^", "\""]
+
+[dependency-groups]
+dev = [
+    "tox>=4.26.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "PyYAML",
     "sphinx>=7.4.0",
     'stdlib_list;python_version<"3.10"',
+    'backports.strenum>=1.3.1;python_version<"3.11"',
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
It seems users can get quite disoriented when switching off "undoc-members" - whole modules will stop rendering even though there may be documented objects within.

This PR adds a config that helps users to debug why items may not be rendering, and also adds an info log for the common case of the module itself missing top level documentation in __init__.py

Interested in your thoughts!