### PR TITLE
Update astroid dependency to avoid breaking release

### DIFF
--- a/docs/changes/536.bugfix.rst
+++ b/docs/changes/536.bugfix.rst
@@ -1,0 +1,1 @@
+Update the pin for astroid to avoid breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    'astroid>=2.7;python_version<"3.12"',
-    'astroid>=3;python_version>="3.12"',
+    'astroid~=3.0',
     "Jinja2",
     "PyYAML",
     "sphinx>=7.4.0",


### PR DESCRIPTION
Potential fix for #536 
Don't let it grab a breaking version of astroid

Unsure why the version for python3.9-3.11 was so low. Tried changing it to allow any 3.x release