### PR TITLE
Document the autoapisummary directive

### DIFF
--- a/docs/changes/377.doc.rst
+++ b/docs/changes/377.doc.rst
@@ -1,0 +1,1 @@
+Document the ``autoapisummary`` directive.

--- a/docs/reference/directives.rst
+++ b/docs/reference/directives.rst
@@ -45,6 +45,31 @@ The following directives are available:
     :rst:dir:`automethod`, and :rst:dir:`autoattribute` respectively.
 
 
+Summary Tables
+--------------
+
+.. rst:directive:: autoapisummary
+
+    Render an autosummary-style table from objects found by AutoAPI's
+    static analysis.
+
+    Each content line is the fully qualified AutoAPI object ID.
+    The table displays the object's short name and docstring summary,
+    and functions include their signature when available.
+
+    For example:
+
+    .. code:: rst
+
+        .. autoapisummary::
+
+           package.module.Example
+           package.module.helper
+
+    This directive is used by AutoAPI's default templates and accepts the
+    same options as :rst:dir:`autosummary`.
+
+
 Inheritance Diagrams
 --------------------
 


### PR DESCRIPTION
Fixes #377.

This adds a short reference entry for `autoapisummary`, including what it renders, how entries are specified, and a small usage example. I also added a towncrier fragment for the docs change.

Checked with:
- `uv run --with tox tox -e doc,release_notes`
- `git diff --check`