### PR TITLE
fix: handle missing original_path during placeholder resolution

### DIFF
--- a/src/autoapi/_mapper.py
+++ b/src/autoapi/_mapper.py
@@ -104,12 +104,25 @@ def _resolve_module_placeholders(modules, module_name, visit_path, resolved):
         if child["type"] != "placeholder":
             continue
 
-        if child["original_path"] in modules:
+        original_path = child.get("original_path")
+
+        if not isinstance(original_path, str) or not original_path:
+            LOGGER.warning(
+                f"Skipping unresolved placeholder in {module_name}: {child}",
+                type="autoapi",
+                subtype="python_import_resolution",
+            )
             module["children"].remove(child)
-            children.pop(child["name"])
+            children.pop(child["name"], None)
             continue
 
-        imported_from, original_name = child["original_path"].rsplit(".", 1)
+        if original_path in modules:
+            module["children"].remove(child)
+            children.pop(child["name"], None)
+            continue
+
+        imported_from, original_name = original_path.rsplit(".", 1)
+
         if imported_from in visit_path:
             visit_str = ", ".join(visit_path)
             msg = f"Cannot resolve cyclic import: {visit_str}, {imported_from}"


### PR DESCRIPTION
## Summary

Prevent AutoAPI from crashing when resolving placeholders with a missing or invalid `original_path`.

Currently `_resolve_module_placeholders()` assumes every placeholder contains a valid string `original_path` and unconditionally calls:

```python
child["original_path"].rsplit(".", 1)
```

In some projects, malformed or unresolved placeholders may contain `None`, causing:

```text
AttributeError: 'NoneType' object has no attribute 'rsplit'
```

This patch defensively validates `original_path` before use, logs a warning, removes the unresolved placeholder, and continues processing instead of aborting the build.

## Result

* Prevents hard crashes during placeholder resolution
* Allows documentation generation to complete successfully
* Preserves existing behavior for valid placeholders

## Validation

* Full tox suite passes
* Formatting, linting, typechecking, docs, and integration tests all pass
