### PR TITLE
Document how to render __init__ separately

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install tox

--- a/doc/changes/532.doc.rst
+++ b/doc/changes/532.doc.rst
@@ -1,0 +1,1 @@
+Document how to render ``__init__`` separately from class docstrings.

--- a/doc/source/reference/config.rst
+++ b/doc/source/reference/config.rst
@@ -134,6 +134,26 @@ Customisation Options
    docstring is empty and the class defines a ``__new__`` with a docstring,
    the ``__new__`` docstring is used instead of the ``__init__`` docstring.
 
+   .. note::
+
+      AutoAPI skips ``__init__`` as a separately rendered method by default,
+      even when ``special-members`` is enabled in
+      :confval:`autoapi_options`.
+      To use only the class docstring for the class page while also rendering
+      ``__init__`` separately, keep ``autoapi_python_class_content = "class"``
+      and connect to :event:`autoapi-skip-member` to include ``__init__``:
+
+      .. code-block:: python
+         :caption: Example conf.py
+
+         def include_init(app, what, name, obj, skip, options):
+             if what == "method" and name.endswith(".__init__"):
+                 return False
+             return None
+
+         def setup(sphinx):
+             sphinx.connect("autoapi-skip-member", include_init)
+
 .. confval:: autoapi_member_order
 
    Default: ``bysource``


### PR DESCRIPTION
Closes #532

This adds a note to autoapi_python_class_content explaining that __init__ is skipped as a separately rendered method by default, even with special-members enabled, and shows how to include it via autoapi-skip-member.

Validation: .tox\doc\Scripts\sphinx-build.exe -b html -d .tox\doc\tmp\doctrees doc\source doc\build\html